### PR TITLE
Audit fixes

### DIFF
--- a/src/COWShedProxy.sol
+++ b/src/COWShedProxy.sol
@@ -50,15 +50,22 @@ contract COWShedProxy is COWShedStorage, Proxy {
 
     /// @dev revert until the initialization has been completed.
     fallback() external payable override {
-        if (!_state().initialized && msg.sig != COWShed.initialize.selector) revert InvalidInitialization();
+        _checkInitialization();
         _fallback();
     }
 
-    receive() external payable { }
+    receive() external payable {
+        _checkInitialization();
+        _fallback();
+    }
 
     function _implementation() internal view override returns (address implementation) {
         assembly {
             implementation := sload(IMPLEMENTATION_STORAGE_SLOT)
         }
+    }
+
+    function _checkInitialization() internal view {
+        if (!_state().initialized && msg.sig != COWShed.initialize.selector) revert InvalidInitialization();
     }
 }

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -43,7 +43,7 @@ abstract contract COWShedResolver is INameResolver, IAddrResolver {
         return LibString.fromSmallString(baseNameSmallString);
     }
 
-    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == IAddrResolver.addr.selector || interfaceId == INameResolver.name.selector;
     }
 

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -43,6 +43,10 @@ abstract contract COWShedResolver is INameResolver, IAddrResolver {
         return LibString.fromSmallString(baseNameSmallString);
     }
 
+    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+        return interfaceId == IAddrResolver.addr.selector || interfaceId == INameResolver.name.selector;
+    }
+
     function _setReverseNode(address user, address proxy) internal {
         bytes32 node = keccak256(abi.encodePacked(ADDR_REVERSE_NODE, sha3HexAddress(proxy)));
         reverseResolutionNodeToAddress[node] = user;

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -5,6 +5,7 @@ import {
     INameResolver, IReverseRegistrar, IENS, IAddrResolver, ENS, ADDR_REVERSE_NODE, sha3HexAddress
 } from "./ens.sol";
 import { LibString } from "solady/utils/LibString.sol";
+import { IERC165 } from "forge-std/interfaces/IERC165.sol";
 
 abstract contract COWShedResolver is INameResolver, IAddrResolver {
     /// @notice maps the `<proxy-address>.<base-name>` node to the user address
@@ -44,7 +45,8 @@ abstract contract COWShedResolver is INameResolver, IAddrResolver {
     }
 
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
-        return interfaceId == IAddrResolver.addr.selector || interfaceId == INameResolver.name.selector;
+        return interfaceId == type(IAddrResolver).interfaceId || interfaceId == type(INameResolver).interfaceId
+            || interfaceId == type(IERC165).interfaceId;
     }
 
     function _setReverseNode(address user, address proxy) internal {

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -7,7 +7,7 @@ import {
 import { LibString } from "solady/utils/LibString.sol";
 import { IERC165 } from "forge-std/interfaces/IERC165.sol";
 
-abstract contract COWShedResolver is INameResolver, IAddrResolver {
+abstract contract COWShedResolver is INameResolver, IAddrResolver, IERC165 {
     /// @notice maps the `<proxy-address>.<base-name>` node to the user address
     mapping(bytes32 => address) public reverseResolutionNodeToAddress;
     /// @notice maps the subnode label hash(`<user>`) to the proxy address


### PR DESCRIPTION
audit finding fixes:
- forward `receive` to implementation contract
- add `supportsInterface` for the ENS interfaces
- catch ens errors, they should not cause hooks execution to fail