### PR TITLE
Enforce formatting rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on: push
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    name: Solidity linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.2.1
+
+      - name: Check Forge formatting rules
+        run: |
+          forge fmt --check
+        id: local-test

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,3 +14,6 @@ via_ir = true
 optimizer_runs = 1_000_000
 
 fs_permissions = [{ access = "write", path = "deploymentAddresses.json"}]
+
+[fmt]
+sort_imports = true

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.25;
 import {Script} from "forge-std/Script.sol";
 import {LibString} from "solady/utils/LibString.sol";
 
-import {COWShedFactory, COWShed} from "src/COWShedFactory.sol";
+import {COWShed, COWShedFactory} from "src/COWShedFactory.sol";
 
 bytes32 constant SALT = bytes32(0);
 

--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import {ICOWAuthHook, Call} from "./ICOWAuthHook.sol";
-import {LibAuthenticatedHooks} from "./LibAuthenticatedHooks.sol";
 import {COWShedStorage, IMPLEMENTATION_STORAGE_SLOT} from "./COWShedStorage.sol";
+import {Call, ICOWAuthHook} from "./ICOWAuthHook.sol";
+import {LibAuthenticatedHooks} from "./LibAuthenticatedHooks.sol";
 import {REVERSE_REGISTRAR} from "./ens.sol";
 
 contract COWShed is ICOWAuthHook, COWShedStorage {

--- a/src/COWShedFactory.sol
+++ b/src/COWShedFactory.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.25;
 
 import {COWShed} from "./COWShed.sol";
-
 import {COWShedProxy} from "./COWShedProxy.sol";
 import {COWShedResolver} from "./COWShedResolver.sol";
 import {Call} from "./ICOWAuthHook.sol";

--- a/src/COWShedFactory.sol
+++ b/src/COWShedFactory.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { COWShed } from "./COWShed.sol";
-import { Call } from "./ICOWAuthHook.sol";
-import { COWShedProxy } from "./COWShedProxy.sol";
-import { COWShedResolver } from "./COWShedResolver.sol";
+import {COWShed} from "./COWShed.sol";
+
+import {COWShedProxy} from "./COWShedProxy.sol";
+import {COWShedResolver} from "./COWShedResolver.sol";
+import {Call} from "./ICOWAuthHook.sol";
 
 contract COWShedFactory is COWShedResolver {
     error InvalidSignature();
@@ -97,7 +98,7 @@ contract COWShedFactory is COWShedResolver {
     function _initializeProxy(address user, address proxy, bool claimResolver) internal returns (bool newlyDeployed) {
         // deploy and initialize proxy if it doesnt exist
         if (proxy.code.length == 0) {
-            COWShedProxy newProxy = new COWShedProxy{ salt: bytes32(uint256(uint160(user))) }(implementation, user);
+            COWShedProxy newProxy = new COWShedProxy{salt: bytes32(uint256(uint160(user)))}(implementation, user);
             COWShed(payable(proxy)).initialize(address(this), claimResolver);
             emit COWShedBuilt(user, address(newProxy));
 

--- a/src/COWShedProxy.sol
+++ b/src/COWShedProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import {COWShed, Call} from "./COWShed.sol";
+import {COWShed} from "./COWShed.sol";
 import {COWShedStorage, IMPLEMENTATION_STORAGE_SLOT} from "./COWShedStorage.sol";
 import {Proxy} from "openzeppelin-contracts/contracts/proxy/Proxy.sol";
 

--- a/src/COWShedProxy.sol
+++ b/src/COWShedProxy.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { COWShedStorage, IMPLEMENTATION_STORAGE_SLOT } from "./COWShedStorage.sol";
-import { COWShed, Call } from "./COWShed.sol";
-import { Proxy } from "openzeppelin-contracts/contracts/proxy/Proxy.sol";
+import {COWShed, Call} from "./COWShed.sol";
+import {COWShedStorage, IMPLEMENTATION_STORAGE_SLOT} from "./COWShedStorage.sol";
+import {Proxy} from "openzeppelin-contracts/contracts/proxy/Proxy.sol";
 
 contract COWShedProxy is COWShedStorage, Proxy {
     error InvalidInitialization();

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import {
-    ADDR_REVERSE_NODE, ENS, IAddrResolver, IENS, INameResolver, IReverseRegistrar, sha3HexAddress
-} from "./ens.sol";
+import {ADDR_REVERSE_NODE, ENS, IAddrResolver, INameResolver, sha3HexAddress} from "./ens.sol";
 import {IERC165} from "forge-std/interfaces/IERC165.sol";
 import {LibString} from "solady/utils/LibString.sol";
 

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -2,10 +2,11 @@
 pragma solidity ^0.8.25;
 
 import {
-    INameResolver, IReverseRegistrar, IENS, IAddrResolver, ENS, ADDR_REVERSE_NODE, sha3HexAddress
+    ADDR_REVERSE_NODE, ENS, IAddrResolver, IENS, INameResolver, IReverseRegistrar, sha3HexAddress
 } from "./ens.sol";
-import { LibString } from "solady/utils/LibString.sol";
-import { IERC165 } from "forge-std/interfaces/IERC165.sol";
+
+import {IERC165} from "forge-std/interfaces/IERC165.sol";
+import {LibString} from "solady/utils/LibString.sol";
 
 abstract contract COWShedResolver is INameResolver, IAddrResolver, IERC165 {
     /// @notice maps the `<proxy-address>.<base-name>` node to the user address
@@ -70,6 +71,6 @@ abstract contract COWShedResolver is INameResolver, IAddrResolver, IERC165 {
         try ENS.setSubnodeRecord(baseNode, label, address(this), address(this), type(uint64).max) {
             success = true;
             forwardResolutionNodeToAddress[subnode] = proxy;
-        } catch (bytes memory) { }
+        } catch (bytes memory) {}
     }
 }

--- a/src/COWShedResolver.sol
+++ b/src/COWShedResolver.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.25;
 import {
     ADDR_REVERSE_NODE, ENS, IAddrResolver, IENS, INameResolver, IReverseRegistrar, sha3HexAddress
 } from "./ens.sol";
-
 import {IERC165} from "forge-std/interfaces/IERC165.sol";
 import {LibString} from "solady/utils/LibString.sol";
 

--- a/src/COWShedStorage.sol
+++ b/src/COWShedStorage.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { LibBitmap } from "solady/utils/LibBitmap.sol";
+import {LibBitmap} from "solady/utils/LibBitmap.sol";
 
 /// @dev bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)
 bytes32 constant IMPLEMENTATION_STORAGE_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;

--- a/src/LibAuthenticatedHooks.sol
+++ b/src/LibAuthenticatedHooks.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { ECDSA } from "solady/utils/ECDSA.sol";
-import { Call } from "./ICOWAuthHook.sol";
+import {Call} from "./ICOWAuthHook.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
 
 interface IERC1271 {
     function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4);
@@ -154,7 +154,7 @@ library LibAuthenticatedHooks {
             if (call.isDelegateCall) {
                 (success, ret) = call.target.delegatecall(call.callData);
             } else {
-                (success, ret) = call.target.call{ value: call.value }(call.callData);
+                (success, ret) = call.target.call{value: call.value}(call.callData);
             }
             if (!success && !call.allowFailure) {
                 // bubble up the revert message

--- a/src/ens.sol
+++ b/src/ens.sol
@@ -49,7 +49,7 @@ bytes32 constant sha3HexLookup = "0123456789abcdef";
  */
 function sha3HexAddress(address who) pure returns (bytes32 ret) {
     assembly {
-        for { let i := 40 } gt(i, 0) { } {
+        for { let i := 40 } gt(i, 0) {} {
             i := sub(i, 1)
             mstore8(i, byte(and(who, 0xf), sha3HexLookup))
             who := div(who, 0x10)

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.25;
 import {Test} from "forge-std/Test.sol";
 import {LibString} from "solady/utils/LibString.sol";
 
-import {COWShedFactory, COWShed} from "src/COWShedFactory.sol";
 import {DeployScript, SALT} from "script/Deploy.s.sol";
+import {COWShed, COWShedFactory} from "src/COWShedFactory.sol";
 
 contract DeployTest is Test {
     string constant TEST_ENS = "base ENS";

--- a/test/LibAuthenticatedHooks.t.sol
+++ b/test/LibAuthenticatedHooks.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { LibAuthenticatedHooks, Call } from "src/LibAuthenticatedHooks.sol";
-import { Test } from "forge-std/Test.sol";
-import { LibAuthenticatedHooksCalldataProxy } from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
+import {Test} from "forge-std/Test.sol";
+import {Call, LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+import {LibAuthenticatedHooksCalldataProxy} from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
 
 // mostly testing the eip712 encoding, hashing, etc.
 // it is differentially tested against the output of ethers' code for
@@ -14,7 +14,7 @@ contract LibAuthenticatedHooksTest is Test {
     function testExecuteHooksHash() external view {
         Call[] memory calls = new Call[](2);
         calls[0] =
-            Call({ target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false });
+            Call({target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false});
         calls[1] = Call({
             target: address(0),
             callData: hex"00112233",
@@ -35,7 +35,7 @@ contract LibAuthenticatedHooksTest is Test {
 
     function testCallHash() external view {
         Call memory call1 =
-            Call({ target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false });
+            Call({target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false});
         Call memory call2 = Call({
             target: address(0),
             callData: hex"00112233",
@@ -59,7 +59,7 @@ contract LibAuthenticatedHooksTest is Test {
     function testCallsHash() external view {
         Call[] memory calls = new Call[](2);
         calls[0] =
-            Call({ target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false });
+            Call({target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false});
         calls[1] = Call({
             target: address(0),
             callData: hex"00112233",

--- a/test/LibAuthenticatedHooks.t.sol
+++ b/test/LibAuthenticatedHooks.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Test} from "forge-std/Test.sol";
-import {Call, LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+import {Call} from "src/LibAuthenticatedHooks.sol";
 import {LibAuthenticatedHooksCalldataProxy} from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
 
 // mostly testing the eip712 encoding, hashing, etc.

--- a/test/forked/BaseForkedTest.sol
+++ b/test/forked/BaseForkedTest.sol
@@ -2,14 +2,16 @@
 pragma solidity ^0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
+
+import {LibString} from "solady/utils/LibString.sol";
 import {COWShed, Call} from "src/COWShed.sol";
-import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
 import {COWShedFactory} from "src/COWShedFactory.sol";
 import {IMPLEMENTATION_STORAGE_SLOT} from "src/COWShedStorage.sol";
-import {ENS, INameResolver, IAddrResolver} from "src/ens.sol";
-import {LibString} from "solady/utils/LibString.sol";
-import {LibAuthenticatedHooksCalldataProxy} from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
+import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+import {ENS, IAddrResolver, INameResolver} from "src/ens.sol";
+
 import {ForkedRpc} from "test/forked/ForkedRpc.sol";
+import {LibAuthenticatedHooksCalldataProxy} from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
 
 /// @dev Simple single owner smart wallet account that will verify signatures against
 ///      pre-approved and stored signatures for given hashes.

--- a/test/forked/BaseForkedTest.sol
+++ b/test/forked/BaseForkedTest.sol
@@ -2,14 +2,12 @@
 pragma solidity ^0.8.25;
 
 import {Test, Vm} from "forge-std/Test.sol";
-
 import {LibString} from "solady/utils/LibString.sol";
 import {COWShed, Call} from "src/COWShed.sol";
 import {COWShedFactory} from "src/COWShedFactory.sol";
 import {IMPLEMENTATION_STORAGE_SLOT} from "src/COWShedStorage.sol";
 import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
 import {ENS, IAddrResolver, INameResolver} from "src/ens.sol";
-
 import {ForkedRpc} from "test/forked/ForkedRpc.sol";
 import {LibAuthenticatedHooksCalldataProxy} from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
 

--- a/test/forked/COWShed.t.sol
+++ b/test/forked/COWShed.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { COWShedStorage, COWShed, Call } from "src/COWShed.sol";
-import { Test, Vm } from "forge-std/Test.sol";
-import { COWShedFactory, COWShedProxy } from "src/COWShedFactory.sol";
-import { BaseForkedTest } from "./BaseForkedTest.sol";
-import { LibAuthenticatedHooks } from "src/LibAuthenticatedHooks.sol";
+import {BaseForkedTest} from "./BaseForkedTest.sol";
+import {Test, Vm} from "forge-std/Test.sol";
+import {COWShed, COWShedStorage, Call} from "src/COWShed.sol";
+import {COWShedFactory, COWShedProxy} from "src/COWShedFactory.sol";
+import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
 
 /// @dev dummy contract
 contract Stub {
@@ -15,7 +15,7 @@ contract Stub {
         revert Revert();
     }
 
-    function callWithValue() external payable { }
+    function callWithValue() external payable {}
 
     function returnUint() external pure returns (uint256) {
         return 420;
@@ -80,8 +80,7 @@ contract ForkedCOWShedTest is BaseForkedTest {
 
     function testExecuteHooksDeadline() external {
         Call[] memory calls = new Call[](1);
-        calls[0] =
-            Call({ target: address(0), value: 0, allowFailure: false, callData: hex"0011", isDelegateCall: false });
+        calls[0] = Call({target: address(0), value: 0, allowFailure: false, callData: hex"0011", isDelegateCall: false});
         bytes32 nonce = "deadline-nonce";
         uint256 deadline = block.timestamp - 1;
         bytes memory signature = _signForProxy(calls, nonce, deadline, user);
@@ -116,8 +115,7 @@ contract ForkedCOWShedTest is BaseForkedTest {
 
     function testRevokeNonce() external {
         Call[] memory calls = new Call[](1);
-        calls[0] =
-            Call({ target: address(0), callData: hex"0011", value: 0, allowFailure: false, isDelegateCall: false });
+        calls[0] = Call({target: address(0), callData: hex"0011", value: 0, allowFailure: false, isDelegateCall: false});
         bytes32 nonce = "nonce-to-revoke";
         bytes memory signature = _signForProxy(calls, nonce, _deadline(), user);
         assertFalse(userProxy.nonces(nonce), "nonce is already used");

--- a/test/forked/COWShed.t.sol
+++ b/test/forked/COWShed.t.sol
@@ -2,9 +2,8 @@
 pragma solidity ^0.8.25;
 
 import {BaseForkedTest} from "./BaseForkedTest.sol";
-import {Test, Vm} from "forge-std/Test.sol";
 import {COWShed, COWShedStorage, Call} from "src/COWShed.sol";
-import {COWShedFactory, COWShedProxy} from "src/COWShedFactory.sol";
+import {COWShedFactory} from "src/COWShedFactory.sol";
 import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
 
 /// @dev dummy contract

--- a/test/forked/COWShedFactory.t.sol
+++ b/test/forked/COWShedFactory.t.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { COWShedFactory } from "src/COWShedFactory.sol";
-import { Vm, Test } from "forge-std/Test.sol";
-import { LibAuthenticatedHooks, Call } from "src/LibAuthenticatedHooks.sol";
-import { COWShed } from "src/COWShed.sol";
-import { BaseForkedTest } from "./BaseForkedTest.sol";
-import { LibString } from "solady/utils/LibString.sol";
-import { ENS } from "src/ens.sol";
+import {BaseForkedTest} from "./BaseForkedTest.sol";
+import {Test, Vm} from "forge-std/Test.sol";
+import {LibString} from "solady/utils/LibString.sol";
+import {COWShed} from "src/COWShed.sol";
+import {COWShedFactory} from "src/COWShedFactory.sol";
+import {Call, LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+
+import {ENS} from "src/ens.sol";
 
 contract ForkedCOWShedFactoryTest is BaseForkedTest {
     error ErrorSettingEns();
@@ -25,10 +26,9 @@ contract ForkedCOWShedFactoryTest is BaseForkedTest {
         address addr2 = makeAddr("addr2");
 
         Call[] memory calls = new Call[](2);
-        calls[0] =
-            Call({ target: addr1, value: 0, callData: hex"00112233", allowFailure: false, isDelegateCall: false });
+        calls[0] = Call({target: addr1, value: 0, callData: hex"00112233", allowFailure: false, isDelegateCall: false});
 
-        calls[1] = Call({ target: addr2, value: 0, callData: hex"11", allowFailure: false, isDelegateCall: false });
+        calls[1] = Call({target: addr2, value: 0, callData: hex"11", allowFailure: false, isDelegateCall: false});
 
         address expectedProxyAddress = factory.proxyOf(wallet.addr);
         assertEq(expectedProxyAddress.code.length, 0, "expectedProxyAddress code is not empty");
@@ -57,9 +57,8 @@ contract ForkedCOWShedFactoryTest is BaseForkedTest {
         address addr2 = makeAddr("addr2");
 
         Call[] memory calls = new Call[](2);
-        calls[0] =
-            Call({ target: addr1, value: 0, callData: hex"00112233", allowFailure: false, isDelegateCall: false });
-        calls[1] = Call({ target: addr2, value: 0, callData: hex"11", allowFailure: false, isDelegateCall: false });
+        calls[0] = Call({target: addr1, value: 0, callData: hex"00112233", allowFailure: false, isDelegateCall: false});
+        calls[1] = Call({target: addr2, value: 0, callData: hex"11", allowFailure: false, isDelegateCall: false});
 
         address expectedProxyAddress = factory.proxyOf(wallet.addr);
         assertEq(expectedProxyAddress.code.length, 0, "expectedProxyAddress code is not empty");
@@ -116,7 +115,7 @@ contract ForkedCOWShedFactoryTest is BaseForkedTest {
         factory.initializeProxy(userAddr, false);
         try this.resolveAddr(userAddr) {
             revert("resolution didnt fail");
-        } catch (bytes memory) { }
+        } catch (bytes memory) {}
         assertGt(proxyAddr.code.length, 0, "proxy is still not initialized");
     }
 

--- a/test/forked/COWShedFactory.t.sol
+++ b/test/forked/COWShedFactory.t.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.25;
 
 import {BaseForkedTest} from "./BaseForkedTest.sol";
-import {Test, Vm} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Test.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {COWShed} from "src/COWShed.sol";
 import {COWShedFactory} from "src/COWShedFactory.sol";
-import {Call, LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+import {Call} from "src/LibAuthenticatedHooks.sol";
 import {ENS} from "src/ens.sol";
 
 contract ForkedCOWShedFactoryTest is BaseForkedTest {

--- a/test/forked/COWShedFactory.t.sol
+++ b/test/forked/COWShedFactory.t.sol
@@ -7,7 +7,6 @@ import {LibString} from "solady/utils/LibString.sol";
 import {COWShed} from "src/COWShed.sol";
 import {COWShedFactory} from "src/COWShedFactory.sol";
 import {Call, LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
-
 import {ENS} from "src/ens.sol";
 
 contract ForkedCOWShedFactoryTest is BaseForkedTest {

--- a/test/forked/COWShedProxy.t.sol
+++ b/test/forked/COWShedProxy.t.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import { COWShed, Call } from "src/COWShed.sol";
-import { BaseForkedTest } from "./BaseForkedTest.sol";
-import { IMPLEMENTATION_STORAGE_SLOT } from "src/COWShedStorage.sol";
-import { COWShedProxy } from "src/COWShedProxy.sol";
-import { ENS, REVERSE_REGISTRAR } from "src/ens.sol";
+import {BaseForkedTest} from "./BaseForkedTest.sol";
+import {COWShed, Call} from "src/COWShed.sol";
+
+import {COWShedProxy} from "src/COWShedProxy.sol";
+import {IMPLEMENTATION_STORAGE_SLOT} from "src/COWShedStorage.sol";
+import {ENS, REVERSE_REGISTRAR} from "src/ens.sol";
 
 contract ForkedCOWShedProxyTest is BaseForkedTest {
     function testAdmin() external {

--- a/test/forked/COWShedProxy.t.sol
+++ b/test/forked/COWShedProxy.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.25;
 
 import {BaseForkedTest} from "./BaseForkedTest.sol";
 import {COWShed, Call} from "src/COWShed.sol";
-
 import {COWShedProxy} from "src/COWShedProxy.sol";
 import {IMPLEMENTATION_STORAGE_SLOT} from "src/COWShedStorage.sol";
 import {ENS, REVERSE_REGISTRAR} from "src/ens.sol";

--- a/test/forked/COWShedProxy.t.sol
+++ b/test/forked/COWShedProxy.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.25;
 import {BaseForkedTest} from "./BaseForkedTest.sol";
 import {COWShed, Call} from "src/COWShed.sol";
 import {COWShedProxy} from "src/COWShedProxy.sol";
-import {IMPLEMENTATION_STORAGE_SLOT} from "src/COWShedStorage.sol";
 import {ENS, REVERSE_REGISTRAR} from "src/ens.sol";
 
 contract ForkedCOWShedProxyTest is BaseForkedTest {

--- a/test/lib/LibAuthenticatedHooksCalldataProxy.sol
+++ b/test/lib/LibAuthenticatedHooksCalldataProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.25;
 
-import {LibAuthenticatedHooks, Call} from "src/LibAuthenticatedHooks.sol";
+import {Call, LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
 
 /// @dev wrapper contract since the LibAuthenticatedHooks library only accepts
 ///      `calldata` params, not `memory` params.


### PR DESCRIPTION
We had many PRs that introduced small logic changes but many changes in the code. This is due to inconsistent code formatting between the existing code in the repo and the people who wrote the PR.

This PR tries to avoid this issue in the future. Namely:
- It runs `forge fmt` on the entire codebase.
- It introduces a new CI step that confirms that the commit formatting is consistent with the repo rules.
- (Opinionated.) It enforces sorted imports.
- It manually removes the newlines introduced by `forge fmt` because of [this bug](https://github.com/foundry-rs/foundry/issues/7944).
- Since I was making changes to the imports anyway, I also removed unused imports (found by `forge lint` on nightly).

### How to test

Check that there's a new CI step and it passes.