### PR TITLE
Fix devdocs

### DIFF
--- a/src/ICOWAuthHook.sol
+++ b/src/ICOWAuthHook.sol
@@ -10,12 +10,12 @@ struct Call {
 }
 
 interface ICOWAuthHook {
-    // @notice execute given calls after authenticating the signature,
-    //         verifying nonce isnt reused and that the deadline hasn't passed.
+    /// @notice execute given calls after authenticating the signature,
+    ///         verifying nonce isnt reused and that the deadline hasn't passed.
     function executeHooks(Call[] calldata calls, bytes32 nonce, uint256 deadline, bytes calldata signature) external;
-    // @notice execute arbitrary calls, only callable by the trusted executor.
+    /// @notice execute arbitrary calls, only callable by the trusted executor.
     function trustedExecuteHooks(Call[] calldata calls) external;
-    // @notice update the trusted executor.
+    /// @notice update the trusted executor.
     function updateTrustedExecutor(address who) external;
     /// @notice on-chain sign a set of hooks. Once signed, the calls can be executed at
     /// any time until the deadline is passed.


### PR DESCRIPTION
Natspec [requires](https://docs.soliditylang.org/en/v0.8.24/style-guide.html#natspec) three backslashes to be a valid comment.

### How to test

`forge build` and see that the compilation output now contains the docs, e.g.:

```
cat out/ICOWAuthHook.sol/ICOWAuthHook.json | jq '.metadata.output.userdoc.methods["updateTrustedExecutor(address)"]'
```