### PR TITLE
Make storage layout compatible with previous version

### DIFF
--- a/src/COWShedStorage.sol
+++ b/src/COWShedStorage.sol
@@ -20,8 +20,8 @@ contract COWShedStorage {
     struct State {
         bool initialized;
         address trustedExecutor;
-        IPreSignStorage preSignStorage;
         LibBitmap.Bitmap nonces;
+        IPreSignStorage preSignStorage;
     }
 
     bytes32 internal constant STATE_STORAGE_SLOT = keccak256("COWShed.State");

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -27,8 +27,8 @@ contract DeployTest is Test {
     function testMatchesOfficialAddresses() external {
         // These addresses are expected to change only if the contract code
         // changes.
-        address officialCowShedAddress = 0xfdD1Bd5c9fAE00D5823Ef5b3F4ad714545b8eDc3;
-        address officialFactoryAddress = 0xf4B1F2AB6Ee816fFD7d4afD6f8B6760446877e4F;
+        address officialCowShedAddress = 0x04F7d65c4Bc27D2c65Be6CAC1FF110E4Eba872f8;
+        address officialFactoryAddress = 0x7B29840D01d4b757b024f312E9F6487fF7946568;
 
         DeployScript.Deployment memory deployment = script.deploy();
 


### PR DESCRIPTION
The auditing process brought up the fact that the changes from c96845c6348e58a306654e967e191d37af757aeb make it impossible to upgrade an old version of the shed to the current version.

An upgrade isn't officially supported, so we don't necessarily advocate for upgrading the shed and CoW Protocol would rather recreate a new shed than upgrading older versions.

Still, there's no reason to knowingly break this process if users want to upgrade on their own responsibility.

### How to test

The upgrade process is unsupported and therefore untested. Still, you can see that the first components of the [old storage struct](https://github.com/cowdao-grants/cow-shed/blob/v1.0.1/src/COWShedStorage.sol#L18-L22) match the new ones, we only add new entries at the end of the struct.
Also, this change doesn't break any unit test and should be safe for use regardless.