### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -20,7 +20,7 @@ contract COWShed is ICOWAuthHook, COWShedStorage {
     event Upgraded(address indexed implementation);
     event PreSignStorageChanged(address indexed newStorage);
 
-    string public constant VERSION = "1.0.1";
+    string public constant VERSION = "1.1.0";
     IPreSignStorage public constant EMPTY_PRE_SIGN_STORAGE = IPreSignStorage(address(0));
 
     bytes32 internal constant domainTypeHash =

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -27,8 +27,8 @@ contract DeployTest is Test {
     function testMatchesOfficialAddresses() external {
         // These addresses are expected to change only if the contract code
         // changes.
-        address officialCowShedAddress = 0x04F7d65c4Bc27D2c65Be6CAC1FF110E4Eba872f8;
-        address officialFactoryAddress = 0x7B29840D01d4b757b024f312E9F6487fF7946568;
+        address officialCowShedAddress = 0x4965Fe1A8D16Dfcc1A6590A9bC995bC7E9E446aD;
+        address officialFactoryAddress = 0x4e91019d28780B70955B0Ed9BA6Fa01C6B87d1E3;
 
         DeployScript.Deployment memory deployment = script.deploy();
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -163,7 +163,7 @@ export class CowShedSdk {
   private _getDomain(proxy: string): TypedDataDomain {
     const domain: TypedDataDomain = {
       name: "COWShed",
-      version: "1.0.1",
+      version: "1.1.0",
       chainId: this.options.chainId,
       verifyingContract: proxy,
     };

--- a/ts/testUtil.ts
+++ b/ts/testUtil.ts
@@ -41,7 +41,7 @@ const cowShedTypes = {
 const typedDomain = {
   chainId: 1,
   name: 'COWShed',
-  version: '1.0.1',
+  version: '1.1.0',
   verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
 };
 


### PR DESCRIPTION
In preparation for a redeployment, the shed version is bumped to 1.1.0. Notably, it introduces a new way to execute transactions. No incompatibilities with version 1.0.1 are known.

### How to test

CI. No instances of 1.0.1 appear in the codebase anymore.