### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -20,7 +20,7 @@ contract COWShed is ICOWAuthHook, COWShedStorage {
     event Upgraded(address indexed implementation);
     event PreSignStorageChanged(address indexed newStorage);
 
-    string public constant VERSION = "1.1.0";
+    string public constant VERSION = "2.0.0";
     IPreSignStorage public constant EMPTY_PRE_SIGN_STORAGE = IPreSignStorage(address(0));
 
     bytes32 internal constant domainTypeHash =

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -27,8 +27,8 @@ contract DeployTest is Test {
     function testMatchesOfficialAddresses() external {
         // These addresses are expected to change only if the contract code
         // changes.
-        address officialCowShedAddress = 0x4965Fe1A8D16Dfcc1A6590A9bC995bC7E9E446aD;
-        address officialFactoryAddress = 0x4e91019d28780B70955B0Ed9BA6Fa01C6B87d1E3;
+        address officialCowShedAddress = 0x62d3a7Ff48F9ae1c28a9552A055482f8C63787F8;
+        address officialFactoryAddress = 0xcf1ADA436dEE1E5923Bd6195aFdb85A4237a6FC0;
 
         DeployScript.Deployment memory deployment = script.deploy();
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -163,7 +163,7 @@ export class CowShedSdk {
   private _getDomain(proxy: string): TypedDataDomain {
     const domain: TypedDataDomain = {
       name: "COWShed",
-      version: "1.1.0",
+      version: "2.0.0",
       chainId: this.options.chainId,
       verifyingContract: proxy,
     };

--- a/ts/testUtil.ts
+++ b/ts/testUtil.ts
@@ -41,7 +41,7 @@ const cowShedTypes = {
 const typedDomain = {
   chainId: 1,
   name: 'COWShed',
-  version: '1.1.0',
+  version: '2.0.0',
   verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
 };
 


### PR DESCRIPTION
We already bumped version to 1.1.0 in 767048f9d752dfb25808139283f009741c60263c, but after some discussion we decided that because of the removal of the ENS feature the contract code makes a breaking change and deserves its own major version bump according to semantic versioning (different function signatures in the initialization). Version 1.1.0 would then officially "disappear" as it would be the same as version 2.0.0.

<details><summary>More points about versioning copied from @anxolin</summary>

For the pre-sign and old flow flows, I would think this version should increase only the "minor version" because

- Just adds new methods for the pre-sign
- Old flows works exactly as it used to
- Storage respect the same position for the data (it just includes additional info at the end of the struct)

Regarding the new admin flow:

- I consider it backward compatible because you can still use the trustedExecuteHooks as before (from the factory), it doesn't matter than now you can also do it from the admin account

However, and here it comes.... I think we need to increase the MAJOR version according to sem versioning because of the ENS change. External function initialize changed its signature, and claimWithResolver is gone.

</details>

### How to test

As in 767048f9d752dfb25808139283f009741c60263c: CI. No instances of 1.0.1 or 1.1.0 appear in the codebase anymore.