### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: v1.2.1
+          version: v1.5.1
 
       - name: Check Forge formatting rules
         run: |

--- a/src/COWShed.sol
+++ b/src/COWShed.sol
@@ -20,7 +20,7 @@ contract COWShed is ICOWAuthHook, COWShedStorage {
     event Upgraded(address indexed implementation);
     event PreSignStorageChanged(address indexed newStorage);
 
-    string public constant VERSION = "2.0.0";
+    string public constant VERSION = "2.1.0";
     IPreSignStorage public constant EMPTY_PRE_SIGN_STORAGE = IPreSignStorage(address(0));
 
     bytes32 internal constant domainTypeHash =

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -29,11 +29,15 @@ contract DeployTest is Test {
         // changes.
         address officialCowShedAddress = 0x62d3a7Ff48F9ae1c28a9552A055482f8C63787F8;
         address officialFactoryAddress = 0xcf1ADA436dEE1E5923Bd6195aFdb85A4237a6FC0;
+        address officialCowShedForComposableCoWAddress = 0x6773d5aA31A1EAD34127D564D6E258E66254EbDb;
+        address officialFactoryForComposableCoWAddress = 0x4F4350bf2c74aaCD508D598a1ba94EF84378793d;
 
         DeployScript.Deployment memory deployment = script.deploy();
 
         assertEq(address(deployment.cowShed), officialCowShedAddress);
         assertEq(address(deployment.factory), officialFactoryAddress);
+        assertEq(address(deployment.cowShedForComposableCoW), officialCowShedForComposableCoWAddress);
+        assertEq(address(deployment.factoryForComposableCoW), officialFactoryForComposableCoWAddress);
     }
 
     function factoryCreationCode(address cowShed) internal pure returns (bytes memory) {

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -36,8 +36,16 @@ contract DeployTest is Test {
 
         assertEq(address(deployment.cowShed), officialCowShedAddress, "incorrect deployment address for COWShed");
         assertEq(address(deployment.factory), officialFactoryAddress, "incorrect deployment address for COWShedFactory");
-        assertEq(address(deployment.cowShedForComposableCoW), officialCowShedForComposableCoWAddress, "incorrect deployment address for COWShedForComposableCoW");
-        assertEq(address(deployment.factoryForComposableCoW), officialFactoryForComposableCoWAddress, "incorrect deployment address for COWShedFactory for ComposableCoW");
+        assertEq(
+            address(deployment.cowShedForComposableCoW),
+            officialCowShedForComposableCoWAddress,
+            "incorrect deployment address for COWShedForComposableCoW"
+        );
+        assertEq(
+            address(deployment.factoryForComposableCoW),
+            officialFactoryForComposableCoWAddress,
+            "incorrect deployment address for COWShedFactory for ComposableCoW"
+        );
     }
 
     function factoryCreationCode(address cowShed) internal pure returns (bytes memory) {

--- a/test/Deploy.t.sol
+++ b/test/Deploy.t.sol
@@ -27,17 +27,17 @@ contract DeployTest is Test {
     function testMatchesOfficialAddresses() external {
         // These addresses are expected to change only if the contract code
         // changes.
-        address officialCowShedAddress = 0x62d3a7Ff48F9ae1c28a9552A055482f8C63787F8;
-        address officialFactoryAddress = 0xcf1ADA436dEE1E5923Bd6195aFdb85A4237a6FC0;
-        address officialCowShedForComposableCoWAddress = 0x6773d5aA31A1EAD34127D564D6E258E66254EbDb;
-        address officialFactoryForComposableCoWAddress = 0x4F4350bf2c74aaCD508D598a1ba94EF84378793d;
+        address officialCowShedAddress = 0xF0D586aB0017fDfE2ACf4AB008B3Ddb2CF50bB09;
+        address officialFactoryAddress = 0xC94F7D71d022e773B0B516841ff867C06f39726B;
+        address officialCowShedForComposableCoWAddress = 0xF0D400089d5b9fACA64E3422AD6614546587cfFB;
+        address officialFactoryForComposableCoWAddress = 0x5E284e80F3bd6A7D80A8500D9c49878028110848;
 
         DeployScript.Deployment memory deployment = script.deploy();
 
-        assertEq(address(deployment.cowShed), officialCowShedAddress);
-        assertEq(address(deployment.factory), officialFactoryAddress);
-        assertEq(address(deployment.cowShedForComposableCoW), officialCowShedForComposableCoWAddress);
-        assertEq(address(deployment.factoryForComposableCoW), officialFactoryForComposableCoWAddress);
+        assertEq(address(deployment.cowShed), officialCowShedAddress, "incorrect deployment address for COWShed");
+        assertEq(address(deployment.factory), officialFactoryAddress, "incorrect deployment address for COWShedFactory");
+        assertEq(address(deployment.cowShedForComposableCoW), officialCowShedForComposableCoWAddress, "incorrect deployment address for COWShedForComposableCoW");
+        assertEq(address(deployment.factoryForComposableCoW), officialFactoryForComposableCoWAddress, "incorrect deployment address for COWShedFactory for ComposableCoW");
     }
 
     function factoryCreationCode(address cowShed) internal pure returns (bytes memory) {

--- a/test/LibAuthenticatedHooks.t.sol
+++ b/test/LibAuthenticatedHooks.t.sol
@@ -18,11 +18,7 @@ contract LibAuthenticatedHooksTest is Test {
         calls[0] =
             Call({target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false});
         calls[1] = Call({
-            target: address(0),
-            callData: hex"00112233",
-            value: 200000000,
-            allowFailure: false,
-            isDelegateCall: false
+            target: address(0), callData: hex"00112233", value: 200000000, allowFailure: false, isDelegateCall: false
         });
 
         bytes32 nonce = bytes32(uint256(1));
@@ -39,11 +35,7 @@ contract LibAuthenticatedHooksTest is Test {
         Call memory call1 =
             Call({target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false});
         Call memory call2 = Call({
-            target: address(0),
-            callData: hex"00112233",
-            value: 200000000,
-            allowFailure: false,
-            isDelegateCall: false
+            target: address(0), callData: hex"00112233", value: 200000000, allowFailure: false, isDelegateCall: false
         });
 
         assertEq(
@@ -63,11 +55,7 @@ contract LibAuthenticatedHooksTest is Test {
         calls[0] =
             Call({target: address(0), callData: hex"1223", value: 20, allowFailure: false, isDelegateCall: false});
         calls[1] = Call({
-            target: address(0),
-            callData: hex"00112233",
-            value: 200000000,
-            allowFailure: false,
-            isDelegateCall: false
+            target: address(0), callData: hex"00112233", value: 200000000, allowFailure: false, isDelegateCall: false
         });
 
         assertEq(

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -163,7 +163,7 @@ export class CowShedSdk {
   private _getDomain(proxy: string): TypedDataDomain {
     const domain: TypedDataDomain = {
       name: "COWShed",
-      version: "2.0.0",
+      version: "2.1.0",
       chainId: this.options.chainId,
       verifyingContract: proxy,
     };

--- a/ts/testUtil.ts
+++ b/ts/testUtil.ts
@@ -41,7 +41,7 @@ const cowShedTypes = {
 const typedDomain = {
   chainId: 1,
   name: 'COWShed',
-  version: '2.0.0',
+  version: '2.1.0',
   verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
 };
 


### PR DESCRIPTION
Version 2.1.0 introduces COWShedForComposableCoW contracts that enable hooks integration with composable CoW orders. This is a minor version bump as it adds new functionality while maintaining backward compatibility with existing COWShed and COWShedFactory contracts.

Updates version references across:
- COWShed smart contract (triggers new smart contract address)
- TypeScript SDK domain separator
- Test utilities
- Deployment tests for new contracts (ensures correct deployment address)
- Bump foundry in CI (good time to do it and it causes lint differences)

post merge, the tag needs to be set for the squash commit. Alternatively, disable squash commit.