### PR TITLE
feat: preconfigured trusted-executor factory and executor-signer shed

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -5,7 +5,9 @@ import {Script} from "forge-std/Script.sol";
 
 import {COWShed, COWShedFactory} from "src/COWShedFactory.sol";
 
+import {COWShedExecutorFactory} from "src/COWShedExecutorFactory.sol";
 import {COWShedForComposableCoW} from "src/COWShedForComposableCoW.sol";
+import {COWShedWithExecutorSigner} from "src/COWShedWithExecutorSigner.sol";
 import {IComposableCow} from "src/IComposableCow.sol";
 
 bytes32 constant SALT = bytes32(0);
@@ -17,8 +19,10 @@ contract DeployScript is Script {
     struct Deployment {
         COWShed cowShed;
         COWShed cowShedForComposableCoW;
+        COWShed cowShedWithExecutorSigner;
         COWShedFactory factory;
         COWShedFactory factoryForComposableCoW;
+        COWShedExecutorFactory factoryForExecutorSigner;
     }
 
     function run() external virtual {
@@ -37,6 +41,10 @@ contract DeployScript is Script {
         vm.broadcast();
         COWShed cowShedForComposableCoW = new COWShedForComposableCoW{salt: SALT}(composableCoW);
 
+        // Deploy COWShed variant that delegates EIP-1271 signature validation to its trusted executor
+        vm.broadcast();
+        COWShed cowShedWithExecutorSigner = new COWShedWithExecutorSigner{salt: SALT}();
+
         // Deploy factory
         vm.broadcast();
         COWShedFactory factory = new COWShedFactory{salt: SALT}(address(cowShed));
@@ -45,11 +53,19 @@ contract DeployScript is Script {
         vm.broadcast();
         COWShedFactory factoryForComposableCoW = new COWShedFactory{salt: SALT}(address(cowShedForComposableCoW));
 
+        // Deploy factory for the executor-signer variant. Integrations use its
+        // (owner, trustedExecutor, salt) overloads to deploy preconfigured proxies.
+        vm.broadcast();
+        COWShedExecutorFactory factoryForExecutorSigner =
+            new COWShedExecutorFactory{salt: SALT}(address(cowShedWithExecutorSigner));
+
         return Deployment({
             cowShed: cowShed,
             cowShedForComposableCoW: cowShedForComposableCoW,
+            cowShedWithExecutorSigner: cowShedWithExecutorSigner,
             factory: factory,
-            factoryForComposableCoW: factoryForComposableCoW
+            factoryForComposableCoW: factoryForComposableCoW,
+            factoryForExecutorSigner: factoryForExecutorSigner
         });
     }
 }

--- a/src/COWShedExecutorFactory.sol
+++ b/src/COWShedExecutorFactory.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {COWShed} from "./COWShed.sol";
+import {COWShedFactory} from "./COWShedFactory.sol";
+import {COWShedProxy} from "./COWShedProxy.sol";
+import {Call} from "./ICOWAuthHook.sol";
+
+/// @title COWShedExecutorFactory
+/// @notice A COWShedFactory that can deploy proxies preconfigured with a specific trusted
+///         executor, at an address that also commits to that executor and a caller-supplied
+///         salt.
+/// @dev Kept as a subclass so the canonical `COWShedFactory` bytecode (and hence its
+///      deterministic deployment address) is untouched. The base per-owner path
+///      (`proxyOf(address)` / `initializeProxy(address)` / `executeHooks(...)`) is inherited
+///      unchanged; this contract only adds the preconfigured-executor overloads.
+contract COWShedExecutorFactory is COWShedFactory {
+    constructor(address impl) COWShedFactory(impl) {}
+
+    /// @notice deterministic address for a proxy preconfigured with a specific trusted executor
+    ///         and salt.
+    /// @dev The trusted executor and salt are committed into the create2 salt (alongside the
+    ///      owner, which is also part of the proxy init code). A different trusted executor or
+    ///      salt therefore yields a different address, so nobody can front-run initialization to
+    ///      preconfigure the proxy at this address with a different executor. The same owner can
+    ///      also have multiple independent proxies by varying `salt`.
+    /// @param owner           - The owner/admin of the proxy.
+    /// @param trustedExecutor - The trusted executor the proxy is initialized with.
+    /// @param salt            - Arbitrary salt to allow multiple proxies per (owner, executor).
+    function proxyOf(address owner, address trustedExecutor, bytes32 salt) public view returns (address) {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(PROXY_CREATION_CODE, abi.encode(implementation, owner)));
+        return address(
+            uint160(
+                uint256(
+                    keccak256(abi.encodePacked(hex"ff", address(this), _create2Salt(owner, trustedExecutor, salt), initCodeHash))
+                )
+            )
+        );
+    }
+
+    /// @notice deploy a proxy preconfigured with a specific trusted executor if not already
+    ///         deployed.
+    /// @param owner           - The owner/admin of the proxy.
+    /// @param trustedExecutor - The trusted executor to initialize the proxy with.
+    /// @param salt            - Arbitrary salt to allow multiple proxies per (owner, executor).
+    /// @return proxy          - The address of the (possibly newly) deployed proxy.
+    function initializeProxy(address owner, address trustedExecutor, bytes32 salt) public returns (address proxy) {
+        proxy = proxyOf(owner, trustedExecutor, salt);
+        if (proxy.code.length == 0) {
+            new COWShedProxy{salt: _create2Salt(owner, trustedExecutor, salt)}(implementation, owner);
+            COWShed(payable(proxy)).initialize(trustedExecutor);
+            emit COWShedBuilt(owner, proxy);
+
+            // set reverse mapping of proxy to owner
+            ownerOf[proxy] = owner;
+        }
+    }
+
+    /// @notice execute hooks on a proxy preconfigured with a specific trusted executor.
+    /// @dev Will deploy and initialize the proxy at a deterministic address if one doesn't
+    ///      already exist. The authorization checks are implemented in COWShed.executeHooks.
+    function executeHooks(
+        Call[] calldata calls,
+        bytes32 nonce,
+        uint256 deadline,
+        address owner,
+        address trustedExecutor,
+        bytes32 salt,
+        bytes calldata signature
+    ) external {
+        address proxy = initializeProxy(owner, trustedExecutor, salt);
+        COWShed(payable(proxy)).executeHooks(calls, nonce, deadline, signature);
+    }
+
+    /// @dev create2 salt committing to the owner, the preconfigured trusted executor and a
+    ///      user-supplied salt. The keccak output is effectively always >= 2**160, so it can
+    ///      never collide with the base per-owner salt `bytes32(uint256(uint160(owner)))`.
+    function _create2Salt(address owner, address trustedExecutor, bytes32 salt) internal pure returns (bytes32) {
+        return keccak256(abi.encode(owner, trustedExecutor, salt));
+    }
+}

--- a/src/COWShedWithExecutorSigner.sol
+++ b/src/COWShedWithExecutorSigner.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {COWShed} from "./COWShed.sol";
+import {IERC1271} from "./IERC1271.sol";
+
+/// @title COWShedWithExecutorSigner
+/// @notice A COWShed variant that is itself an EIP-1271 signer, delegating order
+///         signature validity to the shed's trusted executor.
+/// @dev Intended for setups where a manager/wrapper contract (the trusted executor)
+///      drives the shed and decides which digests the shed will "sign" on-chain
+///      (e.g. by blessing a settlement digest in transient storage), without the
+///      owner having to sign every order. The executor implements the full policy;
+///      the shed simply forwards to it.
+contract COWShedWithExecutorSigner is COWShed, IERC1271 {
+    /// @inheritdoc IERC1271
+    /// @dev Forwards to the trusted executor's own `isValidSignature`. Fails closed
+    ///      (returns `bytes4(0)`) when the executor is unset or an EOA, since an EOA
+    ///      cannot implement EIP-1271. The executor may implement any policy it likes,
+    ///      including an owner-signature fallback.
+    function isValidSignature(bytes32 hash, bytes calldata signature)
+        external
+        view
+        override
+        returns (bytes4)
+    {
+        address executor = _state().trustedExecutor;
+        if (executor.code.length == 0) {
+            return bytes4(0);
+        }
+        return IERC1271(executor).isValidSignature(hash, signature);
+    }
+}

--- a/test/COWShedWithExecutorSigner.t.sol
+++ b/test/COWShedWithExecutorSigner.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {BaseTest} from "./BaseTest.sol";
+import {Vm} from "forge-std/Test.sol";
+import {COWShed, Call} from "src/COWShed.sol";
+import {COWShedExecutorFactory} from "src/COWShedExecutorFactory.sol";
+import {COWShedProxy} from "src/COWShedProxy.sol";
+import {COWShedWithExecutorSigner} from "src/COWShedWithExecutorSigner.sol";
+import {IERC1271} from "src/IERC1271.sol";
+import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+
+/// @dev Minimal trusted-executor stand-in: acts as an EIP-1271 authority (blesses digests)
+///      and can be pranked as the caller of `trustedExecuteHooks`.
+contract MockExecutor is IERC1271 {
+    mapping(bytes32 => bool) public blessed;
+
+    function bless(bytes32 hash, bool ok) external {
+        blessed[hash] = ok;
+    }
+
+    function isValidSignature(bytes32 hash, bytes calldata) external view override returns (bytes4) {
+        return blessed[hash] ? LibAuthenticatedHooks.MAGIC_VALUE_1271 : bytes4(0);
+    }
+}
+
+contract COWShedWithExecutorSignerTest is BaseTest {
+    COWShed executorSignerImpl;
+    COWShedExecutorFactory executorFactory;
+    MockExecutor executor;
+
+    bytes32 constant SALT_A = bytes32(uint256(1));
+    bytes32 constant SALT_B = bytes32(uint256(2));
+
+    function setUp() public override {
+        super.setUp();
+
+        executorSignerImpl = new COWShedWithExecutorSigner();
+        executorFactory = new COWShedExecutorFactory(address(executorSignerImpl));
+        executor = new MockExecutor();
+    }
+
+    // --- address binding ---------------------------------------------------
+
+    function testDeploysAtPredictedAddressWithExecutor() external {
+        address predicted = executorFactory.proxyOf(user.addr, address(executor), SALT_A);
+        assertEq(predicted.code.length, 0, "already deployed");
+
+        address deployed = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        assertEq(deployed, predicted, "deployed at unexpected address");
+        assertGt(deployed.code.length, 0, "not deployed");
+
+        // preconfigured executor is set, owner (admin) is preserved
+        assertEq(COWShed(payable(deployed)).trustedExecutor(), address(executor), "executor not preconfigured");
+        assertEq(executorFactory.ownerOf(deployed), user.addr, "ownerOf not recorded");
+        vm.prank(deployed);
+        assertEq(COWShedProxy(payable(deployed)).admin(), user.addr, "admin should be the owner");
+    }
+
+    function testAddressCommitsToExecutorAndSalt() external {
+        address a = executorFactory.proxyOf(user.addr, address(executor), SALT_A);
+        // different salt -> different shed for the same (owner, executor)
+        address b = executorFactory.proxyOf(user.addr, address(executor), SALT_B);
+        // different executor -> different address (grief-free)
+        address c = executorFactory.proxyOf(user.addr, makeAddr("otherExecutor"), SALT_A);
+        // legacy per-owner path is distinct from any preconfigured address
+        address legacy = executorFactory.proxyOf(user.addr);
+
+        assertTrue(a != b, "salt should change address");
+        assertTrue(a != c, "executor should change address");
+        assertTrue(a != legacy && b != legacy && c != legacy, "should differ from legacy path");
+    }
+
+    function testInitializeProxyIsIdempotent() external {
+        address first = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        address second = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        assertEq(first, second, "should return the same proxy");
+    }
+
+    // --- executor powers ---------------------------------------------------
+
+    function testPreconfiguredExecutorCanTrustedExecute() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        vm.deal(proxy, 1 ether);
+
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: makeAddr("sink"),
+            value: 0.1 ether,
+            callData: hex"",
+            allowFailure: false,
+            isDelegateCall: false
+        });
+
+        vm.prank(address(executor));
+        COWShed(payable(proxy)).trustedExecuteHooks(calls);
+        assertEq(makeAddr("sink").balance, 0.1 ether, "executor call did not run");
+    }
+
+    function testRandomCallerCannotTrustedExecute() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        Call[] memory calls = new Call[](0);
+
+        vm.expectRevert(COWShed.OnlyTrustedRole.selector);
+        vm.prank(makeAddr("randomCaller"));
+        COWShed(payable(proxy)).trustedExecuteHooks(calls);
+    }
+
+    function testOwnerCanExecuteHooksWithSignature() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        vm.deal(proxy, 1 ether);
+
+        address sink = makeAddr("sink");
+        Call[] memory calls = new Call[](1);
+        calls[0] =
+            Call({target: sink, value: 0.2 ether, callData: hex"", allowFailure: false, isDelegateCall: false});
+
+        bytes32 nonce = "1";
+        bytes memory sig = _signForShed(proxy, calls, nonce, _deadline());
+        COWShed(payable(proxy)).executeHooks(calls, nonce, _deadline(), sig);
+        assertEq(sink.balance, 0.2 ether, "owner-signed hook did not run");
+    }
+
+    function testOwnerCanSwapExecutor() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        address newExecutor = makeAddr("newExecutor");
+
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({
+            target: proxy,
+            value: 0,
+            callData: abi.encodeCall(COWShed.updateTrustedExecutor, (newExecutor)),
+            allowFailure: false,
+            isDelegateCall: false
+        });
+        bytes32 nonce = "swap";
+        bytes memory sig = _signForShed(proxy, calls, nonce, _deadline());
+        COWShed(payable(proxy)).executeHooks(calls, nonce, _deadline(), sig);
+
+        assertEq(COWShed(payable(proxy)).trustedExecutor(), newExecutor, "executor not swapped");
+    }
+
+    // --- EIP-1271 delegation ----------------------------------------------
+
+    function testIsValidSignatureDelegatesToExecutor() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+        bytes32 orderDigest = keccak256("some order digest");
+
+        // not blessed yet
+        assertEq(IERC1271(proxy).isValidSignature(orderDigest, hex""), bytes4(0), "should not be valid");
+
+        // executor blesses the digest -> shed reports it valid
+        executor.bless(orderDigest, true);
+        assertEq(
+            IERC1271(proxy).isValidSignature(orderDigest, hex""),
+            LibAuthenticatedHooks.MAGIC_VALUE_1271,
+            "should be valid once blessed"
+        );
+
+        // revoked -> invalid again
+        executor.bless(orderDigest, false);
+        assertEq(IERC1271(proxy).isValidSignature(orderDigest, hex""), bytes4(0), "should be invalid after revoke");
+    }
+
+    function testIsValidSignatureFailsClosedForEoaExecutor() external {
+        address eoaExecutor = makeAddr("eoaExecutor");
+        address proxy = executorFactory.initializeProxy(user.addr, eoaExecutor, SALT_A);
+        assertEq(
+            IERC1271(proxy).isValidSignature(keccak256("x"), hex""),
+            bytes4(0),
+            "EOA executor should fail closed"
+        );
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    function _signForShed(address proxy, Call[] memory calls, bytes32 nonce, uint256 deadline)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 domainSeparator = COWShed(payable(proxy)).domainSeparator();
+        bytes32 digest = cproxy.hashToSign(calls, nonce, deadline, domainSeparator);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user.privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+}


### PR DESCRIPTION
## What

Adds a way to deploy a shed preconfigured with a specific **trusted executor**, and a shed variant that lets that executor authorize orders on-chain.

- **`COWShedExecutorFactory`** — a `COWShedFactory` subclass. `proxyOf(owner, trustedExecutor, salt)` deploys at an address that commits to all three, and initializes the proxy with the given `trustedExecutor` instead of the factory. Kept as a subclass so the canonical factory bytecode/address is untouched; the base per-owner path is inherited unchanged.
- **`COWShedWithExecutorSigner`** — a `COWShed` that is itself an EIP-1271 signer, delegating `isValidSignature` to its trusted executor. Fails closed (`bytes4(0)`) when the executor is unset or an EOA.
- **`Deploy.s.sol`** — deploys the new impl + factory alongside the existing ones.

## Why

Lets a manager/wrapper contract (the trusted executor) drive a shed and bless order/settlement digests on-chain, so the owner doesn't have to sign every order. Committing `(owner, trustedExecutor, salt)` into the address means a different executor/salt yields a different shed, so initialization can't be front-run, and one owner can have multiple independent sheds.

## Reviewers
I suggest you start with they gist of the change is:
- the new Shed which delegates to the trusted executor 1271 verification `COWShedWithExecutorSigner`. 
- The new factory `COWShedExecutorFactory`. 

I tried to keep changes minimal, so the factory inherits from the canonical factory (`COWShedFactory`) and I didn't need to change shed implementation.

The new shed needs minimal changes, it inherits from `COWShed`, so required minimal changes. 

Once familiar with the changes, you can see the tests.

## Test plan

```bash
forge test --match-path test/COWShedWithExecutorSigner.t.sol -vv
```
