### PR TITLE
feat: EOA-owned shed as CoW order trader via Permit2 (prototype)

### DIFF
--- a/src/COWShedWithOwnerSigner.sol
+++ b/src/COWShedWithOwnerSigner.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {COWShed} from "./COWShed.sol";
+import {IERC1271} from "./IERC1271.sol";
+import {LibAuthenticatedHooks} from "./LibAuthenticatedHooks.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
+
+/// @title COWShedWithOwnerSigner
+/// @notice A COWShed variant that is itself an EIP-1271 signer: it "signs" any
+///         digest (e.g. a CoW Protocol order) that carries a valid ECDSA
+///         signature from the shed's owner (admin).
+/// @dev Intended for setups where an EOA holds the funds, uses its shed as the
+///      order trader, and authorizes each order by signing the order digest
+///      directly. The settlement contract validates the order via
+///      `isValidSignature`, which recovers the signer and checks it matches the
+///      owner. No per-order on-chain state is needed.
+contract COWShedWithOwnerSigner is COWShed, IERC1271 {
+    /// @inheritdoc IERC1271
+    /// @dev Returns the magic value iff `signature` is a valid ECDSA signature
+    ///      over `hash` produced by the shed's owner (admin). Fails closed
+    ///      (returns `bytes4(0)`) on a malformed signature or signer mismatch.
+    function isValidSignature(bytes32 hash, bytes calldata signature)
+        external
+        view
+        override
+        returns (bytes4)
+    {
+        address recovered = ECDSA.tryRecoverCalldata(hash, signature);
+        if (recovered != address(0) && recovered == _admin()) {
+            return LibAuthenticatedHooks.MAGIC_VALUE_1271;
+        }
+        return bytes4(0);
+    }
+}

--- a/test/COWShedPermit2Swap.t.sol
+++ b/test/COWShedPermit2Swap.t.sol
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {COWShed, Call} from "src/COWShed.sol";
+import {COWShedFactory} from "src/COWShedFactory.sol";
+import {COWShedWithOwnerSigner} from "src/COWShedWithOwnerSigner.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {LibCowOrder} from "src/LibCowOrder.sol";
+import {LibAuthenticatedHooksCalldataProxy} from "test/lib/LibAuthenticatedHooksCalldataProxy.sol";
+import {MockERC20} from "test/lib/MockERC20.sol";
+import {MockPermit2} from "test/lib/MockPermit2.sol";
+import {MockSettlement, MockVaultRelayer} from "test/lib/MockGPv2.sol";
+
+/// @notice Prototype: an EOA holds the funds and uses its cow-shed as the CoW
+///         Protocol order trader. A pre-hook pulls the funds EOA -> shed via
+///         Permit2 and approves the vault relayer; the order itself is
+///         authorized by the EOA signing the order digest, which the shed
+///         validates via EIP-1271.
+///
+/// Signatures produced by the EOA:
+///   1. Permit2 SignatureTransfer permit (spender = shed) -> lets the shed pull funds.
+///   2. cow-shed executeHooks batch          -> authorizes the pre-hook calls.
+///   3. CoW order digest                     -> authorizes the order (EIP-1271 via shed).
+contract COWShedPermit2SwapTest is Test {
+    using LibCowOrder for LibCowOrder.Data;
+
+    Vm.Wallet user;
+    address shed;
+    address solver = makeAddr("solver");
+
+    COWShedWithOwnerSigner impl;
+    COWShedFactory factory;
+    LibAuthenticatedHooksCalldataProxy cproxy;
+
+    MockPermit2 permit2;
+    MockSettlement settlement;
+    MockVaultRelayer relayer;
+
+    MockERC20 sellToken; // e.g. WETH
+    MockERC20 buyToken; // e.g. USDC
+
+    bytes32 constant KIND_SELL = keccak256("sell");
+    bytes32 constant BALANCE_ERC20 = keccak256("erc20");
+
+    uint256 constant SELL_AMOUNT = 1 ether;
+    uint256 constant BUY_AMOUNT = 2000 ether; // pretend price
+    uint256 constant EOA_START = 10 ether;
+    uint256 constant SETTLEMENT_BUFFER = 1_000_000 ether;
+
+    function setUp() public {
+        user = vm.createWallet("user");
+
+        impl = new COWShedWithOwnerSigner();
+        factory = new COWShedFactory(address(impl));
+        cproxy = new LibAuthenticatedHooksCalldataProxy();
+
+        permit2 = new MockPermit2();
+        settlement = new MockSettlement();
+        relayer = settlement.vaultRelayer();
+        settlement.setSolver(solver, true);
+
+        sellToken = new MockERC20("Wrapped Ether", "WETH");
+        buyToken = new MockERC20("USD Coin", "USDC");
+
+        shed = factory.proxyOf(user.addr);
+
+        // EOA is funded and grants the one-time Permit2 allowance.
+        sellToken.mint(user.addr, EOA_START);
+        vm.prank(user.addr);
+        sellToken.approve(address(permit2), type(uint256).max);
+
+        // Settlement holds a buffer of the buy token to deliver.
+        buyToken.mint(address(settlement), SETTLEMENT_BUFFER);
+    }
+
+    function testSwapWithShedAsTrader() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes32 hookNonce = "swap-1";
+        uint256 permitNonce = 0;
+
+        // --- 1. Permit2 permit signed by the EOA, spender = shed ---
+        MockPermit2.PermitTransferFrom memory permit = MockPermit2.PermitTransferFrom({
+            permitted: MockPermit2.TokenPermissions({token: address(sellToken), amount: SELL_AMOUNT}),
+            nonce: permitNonce,
+            deadline: deadline
+        });
+        bytes memory permitSig = _signPermit2(permit, shed);
+
+        // --- 2. cow-shed hook batch: pull funds via Permit2 + approve relayer ---
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            target: address(permit2),
+            value: 0,
+            callData: abi.encodeCall(
+                MockPermit2.permitTransferFrom,
+                (
+                    permit,
+                    MockPermit2.SignatureTransferDetails({to: shed, requestedAmount: SELL_AMOUNT}),
+                    user.addr,
+                    permitSig
+                )
+            ),
+            allowFailure: false,
+            isDelegateCall: false
+        });
+        calls[1] = Call({
+            target: address(sellToken),
+            value: 0,
+            callData: abi.encodeCall(IERC20.approve, (address(relayer), SELL_AMOUNT)),
+            allowFailure: false,
+            isDelegateCall: false
+        });
+        bytes memory hookSig = _signHookBatch(calls, hookNonce, deadline);
+
+        // --- 3. the CoW order, trader = shed, receiver = EOA ---
+        LibCowOrder.Data memory order = LibCowOrder.Data({
+            sellToken: IERC20(address(sellToken)),
+            buyToken: IERC20(address(buyToken)),
+            receiver: user.addr,
+            sellAmount: SELL_AMOUNT,
+            buyAmount: BUY_AMOUNT,
+            validTo: uint32(deadline),
+            appData: bytes32(0),
+            feeAmount: 0,
+            kind: KIND_SELL,
+            partiallyFillable: false,
+            sellTokenBalance: BALANCE_ERC20,
+            buyTokenBalance: BALANCE_ERC20
+        });
+        bytes memory orderSig = _signOrder(order);
+
+        // --- 4. solver settles: pre-interaction runs the hook, then the swap ---
+        MockSettlement.Interaction[] memory preInteractions = new MockSettlement.Interaction[](1);
+        preInteractions[0] = MockSettlement.Interaction({
+            target: address(factory),
+            value: 0,
+            callData: abi.encodeCall(
+                COWShedFactory.executeHooks, (calls, hookNonce, deadline, user.addr, hookSig)
+            )
+        });
+
+        vm.prank(solver);
+        settlement.settle(preInteractions, order, orderSig, MockSettlement.SigningScheme.Eip1271, BUY_AMOUNT);
+
+        // --- assertions ---
+        assertGt(shed.code.length, 0, "shed should be deployed by the hook");
+        assertEq(sellToken.balanceOf(user.addr), EOA_START - SELL_AMOUNT, "EOA sell balance");
+        assertEq(sellToken.balanceOf(shed), 0, "shed should hold no leftover sell token");
+        assertEq(sellToken.balanceOf(address(settlement)), SELL_AMOUNT, "settlement received sell token");
+        assertEq(buyToken.balanceOf(user.addr), BUY_AMOUNT, "EOA received buy token");
+        assertEq(buyToken.balanceOf(address(settlement)), SETTLEMENT_BUFFER - BUY_AMOUNT, "settlement buffer spent");
+    }
+
+    function testSettleRevertsWithForgedOrderSignature() public {
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // deploy + fund the shed so the sell-side transfer isn't what fails
+        _deployShedWithFunds(deadline);
+
+        LibCowOrder.Data memory order = _baseOrder(deadline);
+
+        // sign the order with a stranger, not the shed owner
+        Vm.Wallet memory stranger = vm.createWallet("stranger");
+        bytes32 digest = order.hash(settlement.domainSeparator());
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(stranger.privateKey, digest);
+        bytes memory orderSig = abi.encodePacked(shed, abi.encodePacked(r, s, v));
+
+        MockSettlement.Interaction[] memory none = new MockSettlement.Interaction[](0);
+        vm.prank(solver);
+        vm.expectRevert(MockSettlement.InvalidOrderSignature.selector);
+        settlement.settle(none, order, orderSig, MockSettlement.SigningScheme.Eip1271, BUY_AMOUNT);
+    }
+
+    function testSettleRevertsForNonSolver() public {
+        uint256 deadline = block.timestamp + 1 hours;
+        LibCowOrder.Data memory order = _baseOrder(deadline);
+        bytes memory orderSig = _signOrder(order);
+        MockSettlement.Interaction[] memory none = new MockSettlement.Interaction[](0);
+
+        vm.prank(makeAddr("notASolver"));
+        vm.expectRevert(MockSettlement.NotASolver.selector);
+        settlement.settle(none, order, orderSig, MockSettlement.SigningScheme.Eip1271, BUY_AMOUNT);
+    }
+
+    // --- helpers -----------------------------------------------------------
+
+    function _baseOrder(uint256 deadline) internal view returns (LibCowOrder.Data memory) {
+        return LibCowOrder.Data({
+            sellToken: IERC20(address(sellToken)),
+            buyToken: IERC20(address(buyToken)),
+            receiver: user.addr,
+            sellAmount: SELL_AMOUNT,
+            buyAmount: BUY_AMOUNT,
+            validTo: uint32(deadline),
+            appData: bytes32(0),
+            feeAmount: 0,
+            kind: KIND_SELL,
+            partiallyFillable: false,
+            sellTokenBalance: BALANCE_ERC20,
+            buyTokenBalance: BALANCE_ERC20
+        });
+    }
+
+    /// @dev Deploy the shed and give it the sell token + relayer approval, so a
+    ///      settlement can proceed past the funding stage without the hook.
+    function _deployShedWithFunds(uint256 deadline) internal {
+        Call[] memory empty = new Call[](0);
+        bytes32 nonce = "init";
+        bytes memory sig = _signHookBatch(empty, nonce, deadline);
+        factory.executeHooks(empty, nonce, deadline, user.addr, sig);
+        sellToken.mint(shed, SELL_AMOUNT);
+        vm.prank(shed);
+        sellToken.approve(address(relayer), SELL_AMOUNT);
+    }
+
+    function _signPermit2(MockPermit2.PermitTransferFrom memory permit, address spender)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 tokenPermissionsHash = keccak256(
+            abi.encode(permit2.TOKEN_PERMISSIONS_TYPEHASH(), permit.permitted.token, permit.permitted.amount)
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                permit2.PERMIT_TRANSFER_FROM_TYPEHASH(),
+                tokenPermissionsHash,
+                spender,
+                permit.nonce,
+                permit.deadline
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", permit2.DOMAIN_SEPARATOR(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user.privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signHookBatch(Call[] memory calls, bytes32 nonce, uint256 deadline)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 digest = cproxy.hashToSign(calls, nonce, deadline, _shedDomainSeparator());
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user.privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signOrder(LibCowOrder.Data memory order) internal view returns (bytes memory) {
+        bytes32 digest = order.hash(settlement.domainSeparator());
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user.privateKey, digest);
+        // GPv2 EIP-1271 encoding: verifier/owner address ++ 1271 signature payload.
+        return abi.encodePacked(shed, abi.encodePacked(r, s, v));
+    }
+
+    /// @dev The shed's COWShed domain separator, computable before deployment.
+    function _shedDomainSeparator() internal view returns (bytes32) {
+        bytes32 domainTypeHash =
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        return keccak256(
+            abi.encode(
+                domainTypeHash, keccak256("COWShed"), keccak256(bytes(impl.VERSION())), block.chainid, shed
+            )
+        );
+    }
+}

--- a/test/lib/MockERC20.sol
+++ b/test/lib/MockERC20.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+/// @dev Minimal mintable ERC20 for prototyping. Not production grade.
+contract MockERC20 {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            require(allowed >= amount, "insufficient allowance");
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "insufficient balance");
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(from, to, amount);
+    }
+}

--- a/test/lib/MockGPv2.sol
+++ b/test/lib/MockGPv2.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC1271} from "src/IERC1271.sol";
+import {LibCowOrder} from "src/LibCowOrder.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
+
+/// @dev Pulls tokens on behalf of the settlement contract, mirroring the real
+///      GPv2VaultRelayer split (traders approve the relayer, not settlement).
+contract MockVaultRelayer {
+    address public immutable settlement;
+
+    constructor() {
+        settlement = msg.sender;
+    }
+
+    function transferFromTrader(IERC20 token, address from, address to, uint256 amount) external {
+        require(msg.sender == settlement, "only settlement");
+        require(token.transferFrom(from, to, amount), "transferFrom failed");
+    }
+}
+
+/// @dev Minimal single-order stand-in for GPv2Settlement. Reproduces the real
+///      order EIP-712 digest (via LibCowOrder + "Gnosis Protocol"/"v2" domain)
+///      and the EIP-1271 signature encoding (owner ++ signature), but settles
+///      exactly one order against the settlement's own buffer instead of a full
+///      batch with clearing prices.
+contract MockSettlement {
+    using LibCowOrder for LibCowOrder.Data;
+
+    error NotASolver();
+    error OrderExpired();
+    error LimitPriceNotRespected();
+    error InvalidOrderSignature();
+    error PreInteractionFailed(bytes reason);
+    error UnsupportedScheme();
+
+    enum SigningScheme {
+        Eip712,
+        EthSign,
+        Eip1271,
+        PreSign
+    }
+
+    struct Interaction {
+        address target;
+        uint256 value;
+        bytes callData;
+    }
+
+    bytes32 internal constant DOMAIN_TYPE_HASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    MockVaultRelayer public immutable vaultRelayer;
+    bytes32 public immutable domainSeparator;
+
+    mapping(address => bool) public solvers;
+
+    constructor() {
+        vaultRelayer = new MockVaultRelayer();
+        solvers[msg.sender] = true;
+        domainSeparator = keccak256(
+            abi.encode(
+                DOMAIN_TYPE_HASH, keccak256("Gnosis Protocol"), keccak256("v2"), block.chainid, address(this)
+            )
+        );
+    }
+
+    function setSolver(address solver, bool allowed) external {
+        solvers[solver] = allowed;
+    }
+
+    /// @notice Settle a single order: run pre-interactions, validate the order
+    ///         signature, pull the sell token from the trader and deliver the
+    ///         buy token from the settlement buffer.
+    /// @param executedBuyAmount buy tokens the solver delivers to the receiver.
+    function settle(
+        Interaction[] calldata preInteractions,
+        LibCowOrder.Data calldata order,
+        bytes calldata signature,
+        SigningScheme scheme,
+        uint256 executedBuyAmount
+    ) external {
+        if (!solvers[msg.sender]) revert NotASolver();
+
+        for (uint256 i = 0; i < preInteractions.length; i++) {
+            (bool ok, bytes memory ret) =
+                preInteractions[i].target.call{value: preInteractions[i].value}(preInteractions[i].callData);
+            if (!ok) revert PreInteractionFailed(ret);
+        }
+
+        LibCowOrder.Data memory ord = order;
+        bytes32 orderDigest = ord.hash(domainSeparator);
+        address owner = _recoverOwner(orderDigest, signature, scheme);
+
+        if (block.timestamp > order.validTo) revert OrderExpired();
+        if (executedBuyAmount < order.buyAmount) revert LimitPriceNotRespected();
+
+        address receiver = order.receiver == address(0) ? owner : order.receiver;
+
+        // Pull the sell token from the trader (the shed) via the relayer.
+        vaultRelayer.transferFromTrader(order.sellToken, owner, address(this), order.sellAmount);
+        // Deliver the buy token from the settlement's buffer.
+        require(order.buyToken.transfer(receiver, executedBuyAmount), "buy transfer failed");
+    }
+
+    function _recoverOwner(bytes32 orderDigest, bytes calldata signature, SigningScheme scheme)
+        internal
+        view
+        returns (address owner)
+    {
+        if (scheme == SigningScheme.Eip1271) {
+            // GPv2 encoding: first 20 bytes = verifier/owner, remainder = 1271 signature.
+            owner = address(bytes20(signature[0:20]));
+            if (IERC1271(owner).isValidSignature(orderDigest, signature[20:]) != 0x1626ba7e) {
+                revert InvalidOrderSignature();
+            }
+        } else if (scheme == SigningScheme.Eip712) {
+            owner = ECDSA.recoverCalldata(orderDigest, signature);
+        } else {
+            revert UnsupportedScheme();
+        }
+    }
+}

--- a/test/lib/MockPermit2.sol
+++ b/test/lib/MockPermit2.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
+
+/// @dev Minimal stand-in for Uniswap's Permit2 `SignatureTransfer`. Reproduces
+///      the real EIP-712 typehashes and digest layout so signing logic matches
+///      production, but simplifies nonce accounting to a plain used-flag mapping.
+///      Only `permitTransferFrom` is implemented.
+contract MockPermit2 {
+    error InvalidSigner();
+    error SignatureExpired();
+    error InvalidAmount();
+    error InvalidNonce();
+
+    struct TokenPermissions {
+        address token;
+        uint256 amount;
+    }
+
+    struct PermitTransferFrom {
+        TokenPermissions permitted;
+        uint256 nonce;
+        uint256 deadline;
+    }
+
+    struct SignatureTransferDetails {
+        address to;
+        uint256 requestedAmount;
+    }
+
+    bytes32 internal constant DOMAIN_TYPE_HASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    bytes32 public constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
+
+    bytes32 public constant PERMIT_TRANSFER_FROM_TYPEHASH = keccak256(
+        "PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)"
+    );
+
+    /// @dev owner => nonce => used
+    mapping(address => mapping(uint256 => bool)) public nonceUsed;
+
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(DOMAIN_TYPE_HASH, keccak256("Permit2"), keccak256("1"), block.chainid, address(this))
+        );
+    }
+
+    /// @notice Transfer tokens from `owner` using their signed permit. The
+    ///         caller (`msg.sender`) is the spender bound into the signature.
+    function permitTransferFrom(
+        PermitTransferFrom calldata permit,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata signature
+    ) external {
+        if (block.timestamp > permit.deadline) revert SignatureExpired();
+        if (transferDetails.requestedAmount > permit.permitted.amount) revert InvalidAmount();
+        if (nonceUsed[owner][permit.nonce]) revert InvalidNonce();
+
+        bytes32 tokenPermissionsHash =
+            keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, permit.permitted.token, permit.permitted.amount));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                PERMIT_TRANSFER_FROM_TYPEHASH, tokenPermissionsHash, msg.sender, permit.nonce, permit.deadline
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+
+        if (ECDSA.recoverCalldata(digest, signature) != owner) revert InvalidSigner();
+
+        nonceUsed[owner][permit.nonce] = true;
+        IERC20(permit.permitted.token).transferFrom(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+}


### PR DESCRIPTION
## What

Prototype: an EOA holds the funds and uses its cow-shed as the CoW Protocol order trader.

- **`COWShedWithOwnerSigner`** — a `COWShed` that is itself an EIP-1271 signer. `isValidSignature(hash, sig)` returns the magic value iff `sig` is a valid ECDSA signature over `hash` from the shed owner (admin); fails closed otherwise. This lets the shed be the order trader while the EOA authorizes each order by signing the order digest directly — no per-order on-chain state.
- **`test/COWShedPermit2Swap.t.sol`** — a self-contained test of the full flow, plus local mocks (`MockPermit2` SignatureTransfer, `MockSettlement`/`MockVaultRelayer` reproducing the real GPv2 order digest + EIP-1271 encoding, `MockERC20`).

## Flow

The EOA does one prior `approve(Permit2, max)` and produces three signatures:

1. **Permit2 permit** (spender = shed) → lets the shed pull funds.
2. **cow-shed `executeHooks` batch** → authorizes the pre-hook: `[permit2.permitTransferFrom(EOA -> shed), sellToken.approve(vaultRelayer)]`.
3. **CoW order digest** → wrapped as `owner ++ sig` and validated via the shed's EIP-1271.

At settlement the solver runs the pre-hook (`factory.executeHooks`, which also deploys the shed on first use), the shed's 1271 validates the order, the relayer pulls the sell token from the shed, and the buy token goes to the EOA.

## Why

Explore funding + trading from an EOA's shed using Permit2, without giving a direct token allowance to the shed. Draft / prototype — uses local mocks, not the real deployed contracts.

## Test plan

```bash
forge test --match-path test/COWShedPermit2Swap.t.sol -vv
forge test   # full suite
```
