### PR TITLE
feat: Accept ERC-712 signatures from the shed's owner to sign ERC-1271 CoW orders

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -15,6 +15,9 @@ bytes32 constant SALT = bytes32(0);
 // See https://github.com/cowprotocol/composable-cow
 address constant DEFAULT_COMPOSABLE_COW = 0xfdaFc9d1902f4e0b84f65F49f244b32b31013b74;
 
+// Canonical GPv2Settlement address (same on all supported networks).
+address constant DEFAULT_SETTLEMENT = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41;
+
 contract DeployScript is Script {
     struct Deployment {
         COWShed cowShed;
@@ -41,9 +44,12 @@ contract DeployScript is Script {
         vm.broadcast();
         COWShed cowShedForComposableCoW = new COWShedForComposableCoW{salt: SALT}(composableCoW);
 
-        // Deploy COWShed variant that delegates EIP-1271 signature validation to its trusted executor
+        // Deploy COWShed variant that delegates EIP-1271 signature validation to its trusted
+        // executor, falling back to owner-signed CoW orders when no executor contract is set
+        address cowSettlement = address(vm.envOr("COW_SETTLEMENT", address(DEFAULT_SETTLEMENT)));
+
         vm.broadcast();
-        COWShed cowShedWithExecutorSigner = new COWShedWithExecutorSigner{salt: SALT}();
+        COWShed cowShedWithExecutorSigner = new COWShedWithExecutorSigner{salt: SALT}(cowSettlement);
 
         // Deploy factory
         vm.broadcast();

--- a/src/COWShedWithExecutorSigner.sol
+++ b/src/COWShedWithExecutorSigner.sol
@@ -9,18 +9,27 @@ import {ECDSA} from "solady/utils/ECDSA.sol";
 /// @title COWShedWithExecutorSigner
 /// @notice A COWShed variant that is itself an EIP-1271 signer. When a trusted executor
 ///         contract is configured it delegates order signature validity to it; otherwise
-///         it accepts the owner's own ECDSA signature.
+///         it accepts the owner's own ECDSA signature, bound to this shed.
 /// @dev Intended for setups where a manager/wrapper contract (the trusted executor)
 ///      drives the shed and decides which digests the shed will "sign" on-chain
 ///      (e.g. by blessing a settlement digest in transient storage), without the
 ///      owner having to sign every order. When no executor contract is set, the shed
-///      behaves as a plain owner-signed smart account for CoW orders.
+///      behaves as an owner-signed smart account for CoW orders.
 contract COWShedWithExecutorSigner is COWShed, IERC1271 {
+    /// @dev EIP-712 type hash for an owner-signed CoW order digest. The digest is wrapped in
+    ///      this struct and hashed under the shed's own domain separator so a signature is only
+    ///      ever valid for THIS shed (see `isValidSignature`).
+    bytes32 internal constant SIGNED_COW_ORDER_TYPE_HASH = keccak256("SignedCowOrder(bytes32 orderDigest)");
+
     /// @inheritdoc IERC1271
-    /// @dev When a trusted executor *contract* is set, forwards to its `isValidSignature`
-    ///      and lets it be authoritative. When no executor contract is set (unset or an EOA,
-    ///      neither of which can implement EIP-1271), falls back to verifying the owner's
-    ///      own ECDSA signature over `hash`. Returns `bytes4(0)` otherwise.
+    /// @dev When a trusted executor *contract* is set, forwards to its `isValidSignature` and
+    ///      lets it be authoritative. When no executor contract is set (unset or an EOA, neither
+    ///      of which can implement EIP-1271), verifies the owner's ECDSA signature over the
+    ///      shed-bound wrapper of `hash` (`SignedCowOrder(orderDigest)` under this shed's domain
+    ///      separator). Binding to the shed's domain separator is what prevents a signature from
+    ///      being replayed to the owner's EOA (which would sign the raw order digest) or to any
+    ///      other shed the owner controls (different `verifyingContract`). Returns `bytes4(0)`
+    ///      otherwise.
     function isValidSignature(bytes32 hash, bytes calldata signature)
         external
         view
@@ -32,12 +41,25 @@ contract COWShedWithExecutorSigner is COWShed, IERC1271 {
             return IERC1271(executor).isValidSignature(hash, signature);
         }
 
-        // No executor contract configured: accept the owner's own ECDSA signature.
-        // `tryRecoverCalldata` returns address(0) for malformed signatures (never reverts).
-        address recovered = ECDSA.tryRecoverCalldata(hash, signature);
+        // No executor contract configured: accept the owner's own ECDSA signature, bound to
+        // this shed. `tryRecoverCalldata` returns address(0) for malformed signatures (never
+        // reverts), so an empty/garbage signature simply fails the owner check below.
+        address recovered = ECDSA.tryRecoverCalldata(_ownerSignedHash(hash), signature);
         if (recovered != address(0) && recovered == _admin()) {
             return LibAuthenticatedHooks.MAGIC_VALUE_1271;
         }
         return bytes4(0);
+    }
+
+    /// @notice The EIP-712 digest the owner must sign to authorize a CoW order digest for this
+    ///         shed. Exposed so integrations can construct the signature off-chain.
+    /// @param orderDigest The GPv2 order digest passed by settlement to `isValidSignature`.
+    function ownerSignedHash(bytes32 orderDigest) external view returns (bytes32) {
+        return _ownerSignedHash(orderDigest);
+    }
+
+    function _ownerSignedHash(bytes32 orderDigest) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(SIGNED_COW_ORDER_TYPE_HASH, orderDigest));
+        return keccak256(abi.encodePacked(hex"1901", domainSeparator(), structHash));
     }
 }

--- a/src/COWShedWithExecutorSigner.sol
+++ b/src/COWShedWithExecutorSigner.sol
@@ -3,21 +3,24 @@ pragma solidity ^0.8.25;
 
 import {COWShed} from "./COWShed.sol";
 import {IERC1271} from "./IERC1271.sol";
+import {LibAuthenticatedHooks} from "./LibAuthenticatedHooks.sol";
+import {ECDSA} from "solady/utils/ECDSA.sol";
 
 /// @title COWShedWithExecutorSigner
-/// @notice A COWShed variant that is itself an EIP-1271 signer, delegating order
-///         signature validity to the shed's trusted executor.
+/// @notice A COWShed variant that is itself an EIP-1271 signer. When a trusted executor
+///         contract is configured it delegates order signature validity to it; otherwise
+///         it accepts the owner's own ECDSA signature.
 /// @dev Intended for setups where a manager/wrapper contract (the trusted executor)
 ///      drives the shed and decides which digests the shed will "sign" on-chain
 ///      (e.g. by blessing a settlement digest in transient storage), without the
-///      owner having to sign every order. The executor implements the full policy;
-///      the shed simply forwards to it.
+///      owner having to sign every order. When no executor contract is set, the shed
+///      behaves as a plain owner-signed smart account for CoW orders.
 contract COWShedWithExecutorSigner is COWShed, IERC1271 {
     /// @inheritdoc IERC1271
-    /// @dev Forwards to the trusted executor's own `isValidSignature`. Fails closed
-    ///      (returns `bytes4(0)`) when the executor is unset or an EOA, since an EOA
-    ///      cannot implement EIP-1271. The executor may implement any policy it likes,
-    ///      including an owner-signature fallback.
+    /// @dev When a trusted executor *contract* is set, forwards to its `isValidSignature`
+    ///      and lets it be authoritative. When no executor contract is set (unset or an EOA,
+    ///      neither of which can implement EIP-1271), falls back to verifying the owner's
+    ///      own ECDSA signature over `hash`. Returns `bytes4(0)` otherwise.
     function isValidSignature(bytes32 hash, bytes calldata signature)
         external
         view
@@ -25,9 +28,16 @@ contract COWShedWithExecutorSigner is COWShed, IERC1271 {
         returns (bytes4)
     {
         address executor = _state().trustedExecutor;
-        if (executor.code.length == 0) {
-            return bytes4(0);
+        if (executor.code.length != 0) {
+            return IERC1271(executor).isValidSignature(hash, signature);
         }
-        return IERC1271(executor).isValidSignature(hash, signature);
+
+        // No executor contract configured: accept the owner's own ECDSA signature.
+        // `tryRecoverCalldata` returns address(0) for malformed signatures (never reverts).
+        address recovered = ECDSA.tryRecoverCalldata(hash, signature);
+        if (recovered != address(0) && recovered == _admin()) {
+            return LibAuthenticatedHooks.MAGIC_VALUE_1271;
+        }
+        return bytes4(0);
     }
 }

--- a/src/COWShedWithExecutorSigner.sol
+++ b/src/COWShedWithExecutorSigner.sol
@@ -8,27 +8,27 @@ import {ECDSA} from "solady/utils/ECDSA.sol";
 
 /// @title COWShedWithExecutorSigner
 /// @notice A COWShed variant that is itself an EIP-1271 signer. When a trusted executor
-///         contract is configured it delegates order signature validity to it; otherwise
-///         it accepts the owner's own ECDSA signature, bound to this shed.
-/// @dev Intended for setups where a manager/wrapper contract (the trusted executor)
-///      drives the shed and decides which digests the shed will "sign" on-chain
-///      (e.g. by blessing a settlement digest in transient storage), without the
-///      owner having to sign every order. When no executor contract is set, the shed
-///      behaves as an owner-signed smart account for CoW orders.
+///         contract is configured it delegates signature validity to it; otherwise it accepts
+///         the owner's own signature over a shed-bound wrapper of the message hash.
+/// @dev Intended for setups where a manager/wrapper contract (the trusted executor) drives the
+///      shed and decides which digests the shed will "sign" on-chain (e.g. by blessing a
+///      settlement digest in transient storage), without the owner having to sign every message.
+///      When no executor contract is set, the shed behaves as a general-purpose owner-signed
+///      EIP-1271 smart account (usable with CoW orders or any other 1271-consuming protocol).
 contract COWShedWithExecutorSigner is COWShed, IERC1271 {
-    /// @dev EIP-712 type hash for an owner-signed CoW order digest. The digest is wrapped in
-    ///      this struct and hashed under the shed's own domain separator so a signature is only
-    ///      ever valid for THIS shed (see `isValidSignature`).
-    bytes32 internal constant SIGNED_COW_ORDER_TYPE_HASH = keccak256("SignedCowOrder(bytes32 orderDigest)");
+    /// @dev EIP-712 type hash for an owner-signed message. An arbitrary EIP-1271 `hash` is
+    ///      wrapped in this struct and hashed under the shed's own domain separator so a
+    ///      signature is only ever valid for THIS shed (see `isValidSignature`).
+    bytes32 internal constant COW_SHED_MESSAGE_TYPE_HASH = keccak256("COWShedMessage(bytes32 hash)");
 
     /// @inheritdoc IERC1271
     /// @dev When a trusted executor *contract* is set, forwards to its `isValidSignature` and
     ///      lets it be authoritative. When no executor contract is set (unset or an EOA, neither
     ///      of which can implement EIP-1271), verifies the owner's ECDSA signature over the
-    ///      shed-bound wrapper of `hash` (`SignedCowOrder(orderDigest)` under this shed's domain
+    ///      shed-bound wrapper of `hash` (`COWShedMessage(hash)` under this shed's domain
     ///      separator). Binding to the shed's domain separator is what prevents a signature from
-    ///      being replayed to the owner's EOA (which would sign the raw order digest) or to any
-    ///      other shed the owner controls (different `verifyingContract`). Returns `bytes4(0)`
+    ///      being replayed to the owner's EOA (which would sign the raw hash) or to any other
+    ///      shed the owner controls (different `verifyingContract`). Returns `bytes4(0)`
     ///      otherwise.
     function isValidSignature(bytes32 hash, bytes calldata signature)
         external
@@ -44,22 +44,19 @@ contract COWShedWithExecutorSigner is COWShed, IERC1271 {
         // No executor contract configured: accept the owner's own ECDSA signature, bound to
         // this shed. `tryRecoverCalldata` returns address(0) for malformed signatures (never
         // reverts), so an empty/garbage signature simply fails the owner check below.
-        address recovered = ECDSA.tryRecoverCalldata(_ownerSignedHash(hash), signature);
+        address recovered = ECDSA.tryRecoverCalldata(toSignedMessageHash(hash), signature);
         if (recovered != address(0) && recovered == _admin()) {
             return LibAuthenticatedHooks.MAGIC_VALUE_1271;
         }
         return bytes4(0);
     }
 
-    /// @notice The EIP-712 digest the owner must sign to authorize a CoW order digest for this
-    ///         shed. Exposed so integrations can construct the signature off-chain.
-    /// @param orderDigest The GPv2 order digest passed by settlement to `isValidSignature`.
-    function ownerSignedHash(bytes32 orderDigest) external view returns (bytes32) {
-        return _ownerSignedHash(orderDigest);
-    }
-
-    function _ownerSignedHash(bytes32 orderDigest) internal view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(SIGNED_COW_ORDER_TYPE_HASH, orderDigest));
+    /// @notice The EIP-712 digest the owner must sign to authorize `hash` for this shed via
+    ///         EIP-1271. Exposed so integrations can construct the signature off-chain.
+    /// @param hash The message hash a consumer passes to `isValidSignature` (e.g. a GPv2 order
+    ///        digest, a Permit2 hash, a login challenge, ...).
+    function toSignedMessageHash(bytes32 hash) public view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(COW_SHED_MESSAGE_TYPE_HASH, hash));
         return keccak256(abi.encodePacked(hex"1901", domainSeparator(), structHash));
     }
 }

--- a/src/COWShedWithExecutorSigner.sol
+++ b/src/COWShedWithExecutorSigner.sol
@@ -4,32 +4,42 @@ pragma solidity ^0.8.25;
 import {COWShed} from "./COWShed.sol";
 import {IERC1271} from "./IERC1271.sol";
 import {LibAuthenticatedHooks} from "./LibAuthenticatedHooks.sol";
+import {LibCowOrder} from "./LibCowOrder.sol";
 import {ECDSA} from "solady/utils/ECDSA.sol";
 
 /// @title COWShedWithExecutorSigner
-/// @notice A COWShed variant that is itself an EIP-1271 signer. When a trusted executor
-///         contract is configured it delegates signature validity to it; otherwise it accepts
-///         the owner's own signature over a shed-bound wrapper of the message hash.
+/// @notice A COWShed variant that is itself an EIP-1271 signer for CoW Protocol orders. When a
+///         trusted executor contract is configured it delegates signature validity to it;
+///         otherwise it verifies the owner's own signature over the full, human-readable order,
+///         bound to this shed.
 /// @dev Intended for setups where a manager/wrapper contract (the trusted executor) drives the
 ///      shed and decides which digests the shed will "sign" on-chain (e.g. by blessing a
-///      settlement digest in transient storage), without the owner having to sign every message.
-///      When no executor contract is set, the shed behaves as a general-purpose owner-signed
-///      EIP-1271 smart account (usable with CoW orders or any other 1271-consuming protocol).
+///      settlement digest in transient storage), without the owner having to sign every order.
+///      When no executor contract is set, the shed behaves as an owner-signed smart account: the
+///      owner signs the CoW order (so a wallet shows the real order fields) under the shed's own
+///      domain separator, and the order is carried in the EIP-1271 signature blob and checked to
+///      reconstruct to exactly the digest CoW is settling. Both digests reuse `LibCowOrder`'s
+///      canonical GPv2 `Order` type, differing only in the EIP-712 domain separator.
 contract COWShedWithExecutorSigner is COWShed, IERC1271 {
-    /// @dev EIP-712 type hash for an owner-signed message. An arbitrary EIP-1271 `hash` is
-    ///      wrapped in this struct and hashed under the shed's own domain separator so a
-    ///      signature is only ever valid for THIS shed (see `isValidSignature`).
-    bytes32 internal constant COW_SHED_MESSAGE_TYPE_HASH = keccak256("COWShedMessage(bytes32 hash)");
+    /// @notice GPv2 settlement contract whose domain separator CoW order digests are built under.
+    address public immutable cowSettlement;
+
+    bytes32 private constant EIP712_DOMAIN_TYPE_HASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    constructor(address _cowSettlement) {
+        cowSettlement = _cowSettlement;
+    }
 
     /// @inheritdoc IERC1271
-    /// @dev When a trusted executor *contract* is set, forwards to its `isValidSignature` and
-    ///      lets it be authoritative. When no executor contract is set (unset or an EOA, neither
-    ///      of which can implement EIP-1271), verifies the owner's ECDSA signature over the
-    ///      shed-bound wrapper of `hash` (`COWShedMessage(hash)` under this shed's domain
-    ///      separator). Binding to the shed's domain separator is what prevents a signature from
-    ///      being replayed to the owner's EOA (which would sign the raw hash) or to any other
-    ///      shed the owner controls (different `verifyingContract`). Returns `bytes4(0)`
-    ///      otherwise.
+    /// @dev When a trusted executor *contract* is set, forwards to its `isValidSignature` and lets
+    ///      it be authoritative. When no executor contract is set (unset or an EOA, neither of
+    ///      which can implement EIP-1271), the `signature` must be `abi.encode(GPv2Order, ownerSig)`:
+    ///      the order is reconstructed and required to hash (under the GPv2 domain separator) to
+    ///      exactly `hash`, and `ownerSig` must be the owner's signature over the same order under
+    ///      this shed's domain separator. Binding to the shed's domain separator prevents the
+    ///      signature from being replayed to the owner's EOA (which signs under the GPv2 domain)
+    ///      or to any other shed the owner controls. Returns `bytes4(0)` otherwise.
     function isValidSignature(bytes32 hash, bytes calldata signature)
         external
         view
@@ -41,22 +51,39 @@ contract COWShedWithExecutorSigner is COWShed, IERC1271 {
             return IERC1271(executor).isValidSignature(hash, signature);
         }
 
-        // No executor contract configured: accept the owner's own ECDSA signature, bound to
-        // this shed. `tryRecoverCalldata` returns address(0) for malformed signatures (never
-        // reverts), so an empty/garbage signature simply fails the owner check below.
-        address recovered = ECDSA.tryRecoverCalldata(toSignedMessageHash(hash), signature);
+        // No executor contract configured: verify the owner's signature over the full order.
+        (LibCowOrder.Data memory order, bytes memory ownerSignature) =
+            abi.decode(signature, (LibCowOrder.Data, bytes));
+
+        // The provided order must be exactly the order CoW is settling...
+        if (LibCowOrder.hash(order, cowDomainSeparator()) != hash) {
+            return bytes4(0);
+        }
+
+        // ...and the owner must have signed that same order under THIS shed's domain separator.
+        // `tryRecover` returns address(0) for malformed signatures (never reverts).
+        address recovered = ECDSA.tryRecover(orderSignedHash(order), ownerSignature);
         if (recovered != address(0) && recovered == _admin()) {
             return LibAuthenticatedHooks.MAGIC_VALUE_1271;
         }
         return bytes4(0);
     }
 
-    /// @notice The EIP-712 digest the owner must sign to authorize `hash` for this shed via
-    ///         EIP-1271. Exposed so integrations can construct the signature off-chain.
-    /// @param hash The message hash a consumer passes to `isValidSignature` (e.g. a GPv2 order
-    ///        digest, a Permit2 hash, a login challenge, ...).
-    function toSignedMessageHash(bytes32 hash) public view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(COW_SHED_MESSAGE_TYPE_HASH, hash));
-        return keccak256(abi.encodePacked(hex"1901", domainSeparator(), structHash));
+    /// @notice The GPv2 domain separator that CoW order digests are computed under.
+    function cowDomainSeparator() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPE_HASH, keccak256("Gnosis Protocol"), keccak256("v2"), block.chainid, cowSettlement
+            )
+        );
+    }
+
+    /// @notice The digest the owner signs to authorize `order` for this shed via EIP-1271: the
+    ///         CoW order hashed under the shed's own domain separator (reusing `LibCowOrder`'s
+    ///         canonical GPv2 `Order` type). Exposed so integrations can build the signature
+    ///         off-chain.
+    /// @param order The GPv2 order the owner is authorizing.
+    function orderSignedHash(LibCowOrder.Data memory order) public view returns (bytes32) {
+        return LibCowOrder.hash(order, domainSeparator());
     }
 }

--- a/test/COWShedWithExecutorSigner.t.sol
+++ b/test/COWShedWithExecutorSigner.t.sol
@@ -255,13 +255,13 @@ contract COWShedWithExecutorSignerTest is BaseTest {
         return abi.encodePacked(r, s, v);
     }
 
-    /// @dev Sign the shed-bound wrapper of `orderDigest` (as an integration would off-chain).
-    function _signShedBoundOrder(address proxy, bytes32 orderDigest, uint256 privateKey)
+    /// @dev Sign the shed-bound wrapper of `hash` (as an integration would off-chain).
+    function _signShedBoundOrder(address proxy, bytes32 hash, uint256 privateKey)
         internal
         view
         returns (bytes memory)
     {
-        bytes32 bound = COWShedWithExecutorSigner(payable(proxy)).ownerSignedHash(orderDigest);
+        bytes32 bound = COWShedWithExecutorSigner(payable(proxy)).toSignedMessageHash(hash);
         return _signHash(bound, privateKey);
     }
 

--- a/test/COWShedWithExecutorSigner.t.sol
+++ b/test/COWShedWithExecutorSigner.t.sol
@@ -9,6 +9,8 @@ import {COWShedProxy} from "src/COWShedProxy.sol";
 import {COWShedWithExecutorSigner} from "src/COWShedWithExecutorSigner.sol";
 import {IERC1271} from "src/IERC1271.sol";
 import {LibAuthenticatedHooks} from "src/LibAuthenticatedHooks.sol";
+import {LibCowOrder} from "src/LibCowOrder.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 /// @dev Minimal trusted-executor stand-in: acts as an EIP-1271 authority (blesses digests)
 ///      and can be pranked as the caller of `trustedExecuteHooks`.
@@ -31,11 +33,12 @@ contract COWShedWithExecutorSignerTest is BaseTest {
 
     bytes32 constant SALT_A = bytes32(uint256(1));
     bytes32 constant SALT_B = bytes32(uint256(2));
+    address constant COW_SETTLEMENT = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41;
 
     function setUp() public override {
         super.setUp();
 
-        executorSignerImpl = new COWShedWithExecutorSigner();
+        executorSignerImpl = new COWShedWithExecutorSigner(COW_SETTLEMENT);
         executorFactory = new COWShedExecutorFactory(address(executorSignerImpl));
         executor = new MockExecutor();
     }
@@ -162,89 +165,111 @@ contract COWShedWithExecutorSignerTest is BaseTest {
         assertEq(IERC1271(proxy).isValidSignature(orderDigest, hex""), bytes4(0), "should be invalid after revoke");
     }
 
-    function testIsValidSignatureAcceptsShedBoundOwnerSignatureWhenNoExecutorContract() external {
-        // executor is an EOA (no code) -> shed falls back to the owner's shed-bound ECDSA signature
+    function testAcceptsOwnerSignedOrderWhenNoExecutorContract() external {
+        // executor is an EOA (no code) -> shed verifies the owner's signature over the order
         address eoaExecutor = makeAddr("eoaExecutor");
         address proxy = executorFactory.initializeProxy(user.addr, eoaExecutor, SALT_A);
 
-        bytes32 orderDigest = keccak256("some order digest");
-        bytes memory ownerSig = _signShedBoundOrder(proxy, orderDigest, user.privateKey);
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes32 cowDigest = _cowDigest(proxy, order);
+        bytes memory sig = abi.encode(order, _signOrder(proxy, order, user.privateKey));
+
         assertEq(
-            IERC1271(proxy).isValidSignature(orderDigest, ownerSig),
+            IERC1271(proxy).isValidSignature(cowDigest, sig),
             LibAuthenticatedHooks.MAGIC_VALUE_1271,
-            "shed-bound owner signature should be accepted"
+            "owner-signed order should be accepted"
         );
     }
 
-    function testIsValidSignatureRejectsRawDigestSignature() external {
-        // A signature over the RAW order digest (what the owner's EOA would sign for a direct
-        // CoW order) must NOT validate for the shed - this is the replay vector.
+    function testRejectsOrderNotMatchingHash() external {
+        // the order in the blob must reconstruct to the exact digest CoW passes
         address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
 
-        bytes32 orderDigest = keccak256("some order digest");
-        bytes memory rawSig = _signHash(orderDigest, user.privateKey);
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes memory sig = abi.encode(order, _signOrder(proxy, order, user.privateKey));
+
         assertEq(
-            IERC1271(proxy).isValidSignature(orderDigest, rawSig),
+            IERC1271(proxy).isValidSignature(keccak256("a different order digest"), sig),
             bytes4(0),
-            "raw-digest signature must not be replayable to the shed"
+            "order must match the settled digest"
         );
     }
 
-    function testShedBoundSignatureDoesNotReplayAcrossSheds() external {
+    function testRejectsRawGpv2SignatureReplay() external {
+        // A signature over the raw GPv2 order digest (what the owner's EOA would sign for a
+        // direct CoW order) must NOT validate for the shed - this is the replay vector.
+        address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
+
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes32 cowDigest = _cowDigest(proxy, order);
+        // owner signs the raw GPv2 digest, not the shed-bound order hash
+        bytes memory sig = abi.encode(order, _signHash(cowDigest, user.privateKey));
+
+        assertEq(
+            IERC1271(proxy).isValidSignature(cowDigest, sig),
+            bytes4(0),
+            "raw GPv2 signature must not be replayable to the shed"
+        );
+    }
+
+    function testOrderSignatureDoesNotReplayAcrossSheds() external {
         // Two sheds for the same owner (different salt) -> different domain separators.
         address proxyA = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
         address proxyB = executorFactory.initializeProxy(user.addr, address(0), SALT_B);
 
-        bytes32 orderDigest = keccak256("some order digest");
-        bytes memory sigForA = _signShedBoundOrder(proxyA, orderDigest, user.privateKey);
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes32 cowDigest = _cowDigest(proxyA, order); // same GPv2 digest regardless of shed
+        bytes memory sigForA = abi.encode(order, _signOrder(proxyA, order, user.privateKey));
 
         assertEq(
-            IERC1271(proxyA).isValidSignature(orderDigest, sigForA),
+            IERC1271(proxyA).isValidSignature(cowDigest, sigForA),
             LibAuthenticatedHooks.MAGIC_VALUE_1271,
             "signature should be valid on the shed it was bound to"
         );
         assertEq(
-            IERC1271(proxyB).isValidSignature(orderDigest, sigForA),
+            IERC1271(proxyB).isValidSignature(cowDigest, sigForA),
             bytes4(0),
             "signature bound to shed A must not validate on shed B"
         );
     }
 
-    function testIsValidSignatureRejectsNonOwnerSignature() external {
+    function testRejectsNonOwnerOrderSignature() external {
         address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
 
         Vm.Wallet memory stranger = vm.createWallet("stranger");
-        bytes32 orderDigest = keccak256("some order digest");
-        bytes memory strangerSig = _signShedBoundOrder(proxy, orderDigest, stranger.privateKey);
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes32 cowDigest = _cowDigest(proxy, order);
+        bytes memory sig = abi.encode(order, _signOrder(proxy, order, stranger.privateKey));
+
         assertEq(
-            IERC1271(proxy).isValidSignature(orderDigest, strangerSig),
-            bytes4(0),
-            "non-owner signature should be rejected"
+            IERC1271(proxy).isValidSignature(cowDigest, sig), bytes4(0), "non-owner signature should be rejected"
         );
     }
 
-    function testIsValidSignatureRejectsMalformedSignatureWhenNoExecutorContract() external {
+    function testRejectsMalformedInnerSignature() external {
         address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
-        // empty / malformed signature -> tryRecover yields address(0) -> rejected, no revert
-        assertEq(IERC1271(proxy).isValidSignature(keccak256("x"), hex""), bytes4(0), "empty sig should be rejected");
-        assertEq(
-            IERC1271(proxy).isValidSignature(keccak256("x"), hex"deadbeef"),
-            bytes4(0),
-            "garbage sig should be rejected"
-        );
+
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes32 cowDigest = _cowDigest(proxy, order);
+        // well-formed blob, but the owner signature is garbage -> tryRecover yields 0, no revert
+        bytes memory sig = abi.encode(order, hex"deadbeef");
+
+        assertEq(IERC1271(proxy).isValidSignature(cowDigest, sig), bytes4(0), "malformed inner sig should reject");
     }
 
-    function testExecutorContractIsAuthoritativeOverOwnerSignature() external {
-        // when an executor contract is configured, a valid owner signature is NOT accepted
+    function testExecutorContractIsAuthoritativeOverOwnerOrder() external {
+        // when an executor contract is configured, a valid owner-signed order is NOT accepted
         // unless the executor itself validates it
         address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
 
-        bytes32 orderDigest = keccak256("some order digest");
-        bytes memory ownerSig = _signShedBoundOrder(proxy, orderDigest, user.privateKey);
+        LibCowOrder.Data memory order = _buildOrder(user.addr);
+        bytes32 cowDigest = _cowDigest(proxy, order);
+        bytes memory sig = abi.encode(order, _signOrder(proxy, order, user.privateKey));
+
         assertEq(
-            IERC1271(proxy).isValidSignature(orderDigest, ownerSig),
+            IERC1271(proxy).isValidSignature(cowDigest, sig),
             bytes4(0),
-            "owner signature must not bypass a configured executor contract"
+            "owner-signed order must not bypass a configured executor contract"
         );
     }
 
@@ -255,13 +280,36 @@ contract COWShedWithExecutorSignerTest is BaseTest {
         return abi.encodePacked(r, s, v);
     }
 
-    /// @dev Sign the shed-bound wrapper of `hash` (as an integration would off-chain).
-    function _signShedBoundOrder(address proxy, bytes32 hash, uint256 privateKey)
+    function _buildOrder(address receiver) internal returns (LibCowOrder.Data memory order) {
+        order = LibCowOrder.Data({
+            sellToken: IERC20(makeAddr("sellToken")),
+            buyToken: IERC20(makeAddr("buyToken")),
+            receiver: receiver,
+            sellAmount: 1 ether,
+            buyAmount: 2 ether,
+            validTo: uint32(block.timestamp + 1 hours),
+            appData: keccak256("appData"),
+            feeAmount: 0,
+            kind: keccak256("sell"),
+            partiallyFillable: false,
+            sellTokenBalance: keccak256("erc20"),
+            buyTokenBalance: keccak256("erc20")
+        });
+    }
+
+    /// @dev The GPv2 order digest CoW settlement would pass to `isValidSignature`.
+    function _cowDigest(address proxy, LibCowOrder.Data memory order) internal view returns (bytes32) {
+        bytes32 cowDs = COWShedWithExecutorSigner(payable(proxy)).cowDomainSeparator();
+        return LibCowOrder.hash(order, cowDs);
+    }
+
+    /// @dev Sign the shed-bound order hash (as an integration would off-chain).
+    function _signOrder(address proxy, LibCowOrder.Data memory order, uint256 privateKey)
         internal
         view
         returns (bytes memory)
     {
-        bytes32 bound = COWShedWithExecutorSigner(payable(proxy)).toSignedMessageHash(hash);
+        bytes32 bound = COWShedWithExecutorSigner(payable(proxy)).orderSignedHash(order);
         return _signHash(bound, privateKey);
     }
 

--- a/test/COWShedWithExecutorSigner.t.sol
+++ b/test/COWShedWithExecutorSigner.t.sol
@@ -162,17 +162,64 @@ contract COWShedWithExecutorSignerTest is BaseTest {
         assertEq(IERC1271(proxy).isValidSignature(orderDigest, hex""), bytes4(0), "should be invalid after revoke");
     }
 
-    function testIsValidSignatureFailsClosedForEoaExecutor() external {
+    function testIsValidSignatureAcceptsOwnerEcdsaWhenNoExecutorContract() external {
+        // executor is an EOA (no code) -> shed falls back to the owner's own ECDSA signature
         address eoaExecutor = makeAddr("eoaExecutor");
         address proxy = executorFactory.initializeProxy(user.addr, eoaExecutor, SALT_A);
+
+        bytes32 orderDigest = keccak256("some order digest");
+        bytes memory ownerSig = _signHash(orderDigest, user.privateKey);
         assertEq(
-            IERC1271(proxy).isValidSignature(keccak256("x"), hex""),
+            IERC1271(proxy).isValidSignature(orderDigest, ownerSig),
+            LibAuthenticatedHooks.MAGIC_VALUE_1271,
+            "owner ECDSA signature should be accepted"
+        );
+    }
+
+    function testIsValidSignatureRejectsNonOwnerEcdsa() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
+
+        Vm.Wallet memory stranger = vm.createWallet("stranger");
+        bytes32 orderDigest = keccak256("some order digest");
+        bytes memory strangerSig = _signHash(orderDigest, stranger.privateKey);
+        assertEq(
+            IERC1271(proxy).isValidSignature(orderDigest, strangerSig),
             bytes4(0),
-            "EOA executor should fail closed"
+            "non-owner signature should be rejected"
+        );
+    }
+
+    function testIsValidSignatureRejectsMalformedSignatureWhenNoExecutorContract() external {
+        address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
+        // empty / malformed signature -> tryRecover yields address(0) -> rejected, no revert
+        assertEq(IERC1271(proxy).isValidSignature(keccak256("x"), hex""), bytes4(0), "empty sig should be rejected");
+        assertEq(
+            IERC1271(proxy).isValidSignature(keccak256("x"), hex"deadbeef"),
+            bytes4(0),
+            "garbage sig should be rejected"
+        );
+    }
+
+    function testExecutorContractIsAuthoritativeOverOwnerEcdsa() external {
+        // when an executor contract is configured, a valid owner ECDSA signature is NOT accepted
+        // unless the executor itself validates it
+        address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
+
+        bytes32 orderDigest = keccak256("some order digest");
+        bytes memory ownerSig = _signHash(orderDigest, user.privateKey);
+        assertEq(
+            IERC1271(proxy).isValidSignature(orderDigest, ownerSig),
+            bytes4(0),
+            "owner ECDSA must not bypass a configured executor contract"
         );
     }
 
     // --- helpers -----------------------------------------------------------
+
+    function _signHash(bytes32 hash, uint256 privateKey) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
+        return abi.encodePacked(r, s, v);
+    }
 
     function _signForShed(address proxy, Call[] memory calls, bytes32 nonce, uint256 deadline)
         internal

--- a/test/COWShedWithExecutorSigner.t.sol
+++ b/test/COWShedWithExecutorSigner.t.sol
@@ -162,26 +162,60 @@ contract COWShedWithExecutorSignerTest is BaseTest {
         assertEq(IERC1271(proxy).isValidSignature(orderDigest, hex""), bytes4(0), "should be invalid after revoke");
     }
 
-    function testIsValidSignatureAcceptsOwnerEcdsaWhenNoExecutorContract() external {
-        // executor is an EOA (no code) -> shed falls back to the owner's own ECDSA signature
+    function testIsValidSignatureAcceptsShedBoundOwnerSignatureWhenNoExecutorContract() external {
+        // executor is an EOA (no code) -> shed falls back to the owner's shed-bound ECDSA signature
         address eoaExecutor = makeAddr("eoaExecutor");
         address proxy = executorFactory.initializeProxy(user.addr, eoaExecutor, SALT_A);
 
         bytes32 orderDigest = keccak256("some order digest");
-        bytes memory ownerSig = _signHash(orderDigest, user.privateKey);
+        bytes memory ownerSig = _signShedBoundOrder(proxy, orderDigest, user.privateKey);
         assertEq(
             IERC1271(proxy).isValidSignature(orderDigest, ownerSig),
             LibAuthenticatedHooks.MAGIC_VALUE_1271,
-            "owner ECDSA signature should be accepted"
+            "shed-bound owner signature should be accepted"
         );
     }
 
-    function testIsValidSignatureRejectsNonOwnerEcdsa() external {
+    function testIsValidSignatureRejectsRawDigestSignature() external {
+        // A signature over the RAW order digest (what the owner's EOA would sign for a direct
+        // CoW order) must NOT validate for the shed - this is the replay vector.
+        address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
+
+        bytes32 orderDigest = keccak256("some order digest");
+        bytes memory rawSig = _signHash(orderDigest, user.privateKey);
+        assertEq(
+            IERC1271(proxy).isValidSignature(orderDigest, rawSig),
+            bytes4(0),
+            "raw-digest signature must not be replayable to the shed"
+        );
+    }
+
+    function testShedBoundSignatureDoesNotReplayAcrossSheds() external {
+        // Two sheds for the same owner (different salt) -> different domain separators.
+        address proxyA = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
+        address proxyB = executorFactory.initializeProxy(user.addr, address(0), SALT_B);
+
+        bytes32 orderDigest = keccak256("some order digest");
+        bytes memory sigForA = _signShedBoundOrder(proxyA, orderDigest, user.privateKey);
+
+        assertEq(
+            IERC1271(proxyA).isValidSignature(orderDigest, sigForA),
+            LibAuthenticatedHooks.MAGIC_VALUE_1271,
+            "signature should be valid on the shed it was bound to"
+        );
+        assertEq(
+            IERC1271(proxyB).isValidSignature(orderDigest, sigForA),
+            bytes4(0),
+            "signature bound to shed A must not validate on shed B"
+        );
+    }
+
+    function testIsValidSignatureRejectsNonOwnerSignature() external {
         address proxy = executorFactory.initializeProxy(user.addr, address(0), SALT_A);
 
         Vm.Wallet memory stranger = vm.createWallet("stranger");
         bytes32 orderDigest = keccak256("some order digest");
-        bytes memory strangerSig = _signHash(orderDigest, stranger.privateKey);
+        bytes memory strangerSig = _signShedBoundOrder(proxy, orderDigest, stranger.privateKey);
         assertEq(
             IERC1271(proxy).isValidSignature(orderDigest, strangerSig),
             bytes4(0),
@@ -200,17 +234,17 @@ contract COWShedWithExecutorSignerTest is BaseTest {
         );
     }
 
-    function testExecutorContractIsAuthoritativeOverOwnerEcdsa() external {
-        // when an executor contract is configured, a valid owner ECDSA signature is NOT accepted
+    function testExecutorContractIsAuthoritativeOverOwnerSignature() external {
+        // when an executor contract is configured, a valid owner signature is NOT accepted
         // unless the executor itself validates it
         address proxy = executorFactory.initializeProxy(user.addr, address(executor), SALT_A);
 
         bytes32 orderDigest = keccak256("some order digest");
-        bytes memory ownerSig = _signHash(orderDigest, user.privateKey);
+        bytes memory ownerSig = _signShedBoundOrder(proxy, orderDigest, user.privateKey);
         assertEq(
             IERC1271(proxy).isValidSignature(orderDigest, ownerSig),
             bytes4(0),
-            "owner ECDSA must not bypass a configured executor contract"
+            "owner signature must not bypass a configured executor contract"
         );
     }
 
@@ -219,6 +253,16 @@ contract COWShedWithExecutorSignerTest is BaseTest {
     function _signHash(bytes32 hash, uint256 privateKey) internal pure returns (bytes memory) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, hash);
         return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Sign the shed-bound wrapper of `orderDigest` (as an integration would off-chain).
+    function _signShedBoundOrder(address proxy, bytes32 orderDigest, uint256 privateKey)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 bound = COWShedWithExecutorSigner(payable(proxy)).ownerSignedHash(orderDigest);
+        return _signHash(bound, privateKey);
     }
 
     function _signForShed(address proxy, Call[] memory calls, bytes32 nonce, uint256 deadline)


### PR DESCRIPTION
## What

Follow-up to #61. 

Adds an owner-signed EIP-1271 path to `COWShedWithExecutorSigner`: when trusted executor is unset.

In this case, the shed validates the **owner's own signature over the CoW order** instead of failing closed.

Behavior:
- If the trusted executor is set: forward to its `isValidSignature` to it. 
- Otherwise: Extract the order and EOA signature from the 1271 signature, and make sure the order matches the order digest, and the EOA signature belong to this specific order and owner of the shed's proxy.

## Why
Removes the need to presign using the shed. Instead we rely in 1271 and an EOA signature. This save us from needing to store the orderUid in the settlement contract (presign flow).


## Replay safety
If we naively accept the EOA signature of a GPv2 order as the signature of the 1271 order, then the same signature could be reused for the EOA or any other shed.

The solution is to include the order struct as part of the signature data. This way, we can use its own domain of the shed (so is binded to the current shed). The EOA signature will be the last bytes of the signature, so we can verify the order was signed by the `owner` of the shed.

Note the domain separator depends on the proxy and not on the CoW shed contract, effectivelly making that if you deploy multiple sheds with the same implementation and different `salt` each one will have different verifying contract, meaning it can't be replayed elsewhere.

## Readable signing, no duplicated types

My initial implementation was just signing the digest, but this would not allow the user to verify the order in their wallet, so I decided to include the order in the signature to make sure that's what the user signs and see.


## Test plan

```
forge test --match-path test/COWShedWithExecutorSigner.t.sol -vv
```