### PR TITLE
feat: Add setup call as part of the shed creation

### DIFF
--- a/src/COWShedExecutorFactory.sol
+++ b/src/COWShedExecutorFactory.sol
@@ -5,6 +5,7 @@ import {COWShed} from "./COWShed.sol";
 import {COWShedFactory} from "./COWShedFactory.sol";
 import {COWShedProxy} from "./COWShedProxy.sol";
 import {Call} from "./ICOWAuthHook.sol";
+import {ICOWShedSetup} from "./ICOWShedSetup.sol";
 
 /// @title COWShedExecutorFactory
 /// @notice A COWShedFactory that can deploy proxies preconfigured with a specific trusted
@@ -77,5 +78,84 @@ contract COWShedExecutorFactory is COWShedFactory {
     ///      never collide with the base per-owner salt `bytes32(uint256(uint160(owner)))`.
     function _create2Salt(address owner, address trustedExecutor, bytes32 salt) internal pure returns (bytes32) {
         return keccak256(abi.encode(owner, trustedExecutor, salt));
+    }
+
+    // --- deploy-time setup call --------------------------------------------------------------
+
+    /// @notice deterministic address for a shed preconfigured with a trusted executor and salt,
+    ///         that also runs a one-time setup call on `setupTarget` at deployment.
+    /// @dev The setup target and data are committed into the create2 salt, so a different setup
+    ///      call yields a different address (grief-free): nobody can deploy the shed at this
+    ///      address with a different setup call. A shed created with a setup call therefore has a
+    ///      different address than the plain `proxyOf(owner, trustedExecutor, salt)`.
+    /// @param owner           - The owner/admin of the proxy.
+    /// @param trustedExecutor - The trusted executor the proxy is initialized with.
+    /// @param salt            - Arbitrary salt to allow multiple proxies per (owner, executor).
+    /// @param setupTarget     - Contract called back via `ICOWShedSetup.setup` right after deploy.
+    /// @param setupData       - Data passed to the setup callback (committed into the address).
+    function proxyOf(
+        address owner,
+        address trustedExecutor,
+        bytes32 salt,
+        address setupTarget,
+        bytes calldata setupData
+    ) public view returns (address) {
+        bytes32 initCodeHash = keccak256(abi.encodePacked(PROXY_CREATION_CODE, abi.encode(implementation, owner)));
+        return address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex"ff",
+                            address(this),
+                            _setupSalt(owner, trustedExecutor, salt, setupTarget, setupData),
+                            initCodeHash
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    /// @notice deploy a preconfigured proxy (if not already deployed) and run a one-time setup
+    ///         call on `setupTarget` in the same transaction.
+    /// @dev The setup call is only executed on first deployment (idempotent), so this can be run
+    ///      as a discardable solver pre-interaction. The callback receives the freshly deployed
+    ///      `proxy` address, which it cannot know from `setupData` alone (that data is committed
+    ///      into the proxy address). If the setup call reverts, the whole deployment reverts.
+    /// @return proxy - The address of the (possibly newly) deployed proxy.
+    function initializeProxyWithSetup(
+        address owner,
+        address trustedExecutor,
+        bytes32 salt,
+        address setupTarget,
+        bytes calldata setupData
+    ) public returns (address proxy) {
+        proxy = proxyOf(owner, trustedExecutor, salt, setupTarget, setupData);
+        if (proxy.code.length == 0) {
+            new COWShedProxy{salt: _setupSalt(owner, trustedExecutor, salt, setupTarget, setupData)}(
+                implementation, owner
+            );
+            COWShed(payable(proxy)).initialize(trustedExecutor);
+            emit COWShedBuilt(owner, proxy);
+
+            // set reverse mapping of proxy to owner
+            ownerOf[proxy] = owner;
+
+            // run the one-time setup call, passing the deployed proxy address to the target
+            ICOWShedSetup(setupTarget).setup(proxy, owner, setupData);
+        }
+    }
+
+    /// @dev create2 salt committing to the owner, trusted executor, user salt, and the setup call
+    ///      (target + data). Binding the setup call makes the deployment grief-free.
+    function _setupSalt(
+        address owner,
+        address trustedExecutor,
+        bytes32 salt,
+        address setupTarget,
+        bytes calldata setupData
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(owner, trustedExecutor, salt, setupTarget, keccak256(setupData)));
     }
 }

--- a/src/ICOWShedSetup.sol
+++ b/src/ICOWShedSetup.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+/// @title ICOWShedSetup
+/// @notice Callback invoked by `COWShedExecutorFactory` immediately after a shed is deployed and
+///         initialized, to perform one-time setup (register the shed with a manager, deploy/kick
+///         the trusted executor, ...) in the same transaction as the deployment.
+/// @dev The factory commits `(setupTarget, setupData)` into the shed's CREATE2 address and then
+///      calls `setup(shed, owner, setupData)` on the target. The `shed` address is supplied at
+///      call time on purpose: it cannot be embedded in `setupData`, since `setupData` is committed
+///      into that very address (a circular dependency). The target is typically the shed's trusted
+///      executor, which - being trusted - can act as the shed via `trustedExecuteHooks`.
+interface ICOWShedSetup {
+    /// @param shed      The freshly deployed shed proxy.
+    /// @param owner     The shed owner/admin.
+    /// @param setupData Arbitrary data committed into the shed address (e.g. a leverage intent).
+    function setup(address shed, address owner, bytes calldata setupData) external;
+}

--- a/test/COWShedExecutorFactorySetup.t.sol
+++ b/test/COWShedExecutorFactorySetup.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {BaseTest} from "./BaseTest.sol";
+import {COWShed, Call} from "src/COWShed.sol";
+import {COWShedExecutorFactory} from "src/COWShedExecutorFactory.sol";
+import {ICOWShedSetup} from "src/ICOWShedSetup.sol";
+
+/// @dev Records its caller and any value received.
+contract Recorder {
+    address public lastCaller;
+    uint256 public pings;
+    uint256 public lastValue;
+
+    function ping() external payable {
+        lastCaller = msg.sender;
+        pings++;
+        lastValue = msg.value;
+    }
+}
+
+/// @dev A setup target that is also the shed's trusted executor. On setup it routes a call
+///      through the shed via `trustedExecuteHooks`, so the final call runs as the shed.
+contract RoutingSetupExecutor is ICOWShedSetup {
+    uint256 public setupCount;
+    address public lastShed;
+    address public lastOwner;
+
+    function setup(address shed, address owner, bytes calldata setupData) external override {
+        setupCount++;
+        lastShed = shed;
+        lastOwner = owner;
+        (address target, uint256 value, bytes memory cd) = abi.decode(setupData, (address, uint256, bytes));
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: target, value: value, callData: cd, allowFailure: false, isDelegateCall: false});
+        COWShed(payable(shed)).trustedExecuteHooks(calls);
+    }
+}
+
+/// @dev A setup target that always reverts.
+contract RevertingSetup is ICOWShedSetup {
+    error SetupBoom();
+
+    function setup(address, address, bytes calldata) external pure override {
+        revert SetupBoom();
+    }
+}
+
+contract COWShedExecutorFactorySetupTest is BaseTest {
+    COWShedExecutorFactory executorFactory;
+    RoutingSetupExecutor routingExecutor;
+    Recorder recorder;
+
+    bytes32 constant SALT = bytes32(uint256(1));
+
+    function setUp() public override {
+        super.setUp();
+        // base COWShed implementation (deployed by BaseTest) behind the executor factory
+        executorFactory = new COWShedExecutorFactory(address(cowshedImpl));
+        routingExecutor = new RoutingSetupExecutor();
+        recorder = new Recorder();
+    }
+
+    function _pingData(uint256 value) internal view returns (bytes memory) {
+        return abi.encode(address(recorder), value, abi.encodeCall(Recorder.ping, ()));
+    }
+
+    function testDeploysAtPredictedAddressAndRunsSetup() external {
+        bytes memory data = _pingData(0);
+        address predicted =
+            executorFactory.proxyOf(user.addr, address(routingExecutor), SALT, address(routingExecutor), data);
+        assertEq(predicted.code.length, 0, "already deployed");
+
+        address deployed = executorFactory.initializeProxyWithSetup(
+            user.addr, address(routingExecutor), SALT, address(routingExecutor), data
+        );
+        assertEq(deployed, predicted, "deployed at unexpected address");
+        assertGt(deployed.code.length, 0, "not deployed");
+
+        // shed is configured with the executor and owner
+        assertEq(COWShed(payable(deployed)).trustedExecutor(), address(routingExecutor), "executor not set");
+        assertEq(executorFactory.ownerOf(deployed), user.addr, "ownerOf not recorded");
+
+        // setup ran once and received the freshly deployed shed address + owner
+        assertEq(routingExecutor.setupCount(), 1, "setup not run once");
+        assertEq(routingExecutor.lastShed(), deployed, "setup got wrong shed");
+        assertEq(routingExecutor.lastOwner(), user.addr, "setup got wrong owner");
+
+        // the routed call executed AS THE SHED (msg.sender == shed at the final target)
+        assertEq(recorder.lastCaller(), deployed, "call did not run as the shed");
+        assertEq(recorder.pings(), 1, "recorder not pinged");
+    }
+
+    function testSetupCallCommitsToAddress() external {
+        bytes memory dataA = _pingData(0);
+        bytes memory dataB = abi.encode(makeAddr("other"), uint256(0), bytes(""));
+
+        address a =
+            executorFactory.proxyOf(user.addr, address(routingExecutor), SALT, address(routingExecutor), dataA);
+        // different setup data -> different address
+        address diffData =
+            executorFactory.proxyOf(user.addr, address(routingExecutor), SALT, address(routingExecutor), dataB);
+        // different setup target -> different address
+        address diffTarget =
+            executorFactory.proxyOf(user.addr, address(routingExecutor), SALT, makeAddr("otherTarget"), dataA);
+        // plain (no-setup) path from #61 is distinct
+        address plain = executorFactory.proxyOf(user.addr, address(routingExecutor), SALT);
+
+        assertTrue(a != diffData, "setup data should change address");
+        assertTrue(a != diffTarget, "setup target should change address");
+        assertTrue(a != plain, "setup path should differ from plain path");
+    }
+
+    function testSetupRunsOnlyOnFirstDeploy() external {
+        bytes memory data = _pingData(0);
+        address first = executorFactory.initializeProxyWithSetup(
+            user.addr, address(routingExecutor), SALT, address(routingExecutor), data
+        );
+        address second = executorFactory.initializeProxyWithSetup(
+            user.addr, address(routingExecutor), SALT, address(routingExecutor), data
+        );
+        assertEq(first, second, "should return the same proxy");
+        assertEq(routingExecutor.setupCount(), 1, "setup should run only once");
+        assertEq(recorder.pings(), 1, "recorder should be pinged only once");
+    }
+
+    function testSetupRevertRevertsDeployment() external {
+        RevertingSetup bad = new RevertingSetup();
+        bytes memory data = hex"";
+        address predicted = executorFactory.proxyOf(user.addr, address(bad), SALT, address(bad), data);
+
+        vm.expectRevert(RevertingSetup.SetupBoom.selector);
+        executorFactory.initializeProxyWithSetup(user.addr, address(bad), SALT, address(bad), data);
+
+        // nothing was deployed, so the deployment can be retried
+        assertEq(predicted.code.length, 0, "should not have deployed when setup reverts");
+    }
+
+    function testSetupCanSpendPreFundedEth() external {
+        bytes memory data = _pingData(0.3 ether);
+        address predicted =
+            executorFactory.proxyOf(user.addr, address(routingExecutor), SALT, address(routingExecutor), data);
+
+        // pre-fund the counterfactual address before it is deployed
+        vm.deal(predicted, 1 ether);
+
+        address deployed = executorFactory.initializeProxyWithSetup(
+            user.addr, address(routingExecutor), SALT, address(routingExecutor), data
+        );
+
+        assertEq(deployed, predicted, "deployed at unexpected address");
+        assertEq(recorder.lastValue(), 0.3 ether, "value not forwarded by the shed");
+        assertEq(address(recorder).balance, 0.3 ether, "recorder did not receive value");
+        assertEq(deployed.balance, 0.7 ether, "shed should retain the remainder");
+    }
+}


### PR DESCRIPTION
## What

Adds a way to **run a one-time setup call in the same transaction**.

This allows to created sheds that not only have a given setup, but also can run some call that do some additional jobs (i.e. registering complex orders).

## Reviewer notes / design choices
### Setup contract and data part of CREATE2
The setup call becomes part of the CREATE2, this way we can invoke init logic in any contract (which could be the trusted executor, allowing to actually do authorised interactions from the shed.

### Proxy implementation is unchanged
I didn't need to change anything in cow-shed, so changes affect the factory only (same as previous PRs)

### shedAddress not part of the setupData, but part of the setup call
The setup call is done through a call to a provided setup contract. This typically could be the trusted executor, so it can perform actions on behalf of the shed's proxy.

Basically calls `setup(shed, owner, setupData)`  (`ICOWShedSetup`)

Notice the shed address is passed and not part of the `setupData` because the `setupData` is also part of the CREATE2 seed, so to break the circular dependency we first deploy the contract and then pass the address. 

### Griefing attacks
Notice the factory adds `setupTarget, setupData` arguments to create a shed, so if someone tries to change any of those changes the shed, so it should be a `grief-free` flow


### Idempotent
Setup runs only on first deploy (inside the `code.length == 0` guard)

It's safe as a discardable solver pre-interaction in case someone front-runs it.


### Account-routing
The setup runs in the factory's context, but the target is typically the shed's `trustedExecutor`, which, if well designed and truste]d, can internally call back into `shed.trustedExecuteHooks(...)` so the actual work runs.

## Test plan

```
forge test --match-path test/COWShedExecutorFactorySetup.t.sol -vv
```


## Out of scope
I realised people can use this pattern to lock themselves into a trap. Poorly designed initialization might lead to the setup call failing, and if this happens, the whole deployment fails. Because this is often used as a counterfactual account that receives funds before the contract is deployed, it is good we have a scape hatch for that.

This is addressed in a follow-up:
https://github.com/cowdao-grants/cow-shed/pull/78