### PR TITLE
feat: validate orders via owner-signed merkle root

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -6,6 +6,7 @@ import {Script} from "forge-std/Script.sol";
 import {COWShed, COWShedFactory} from "src/COWShedFactory.sol";
 
 import {COWShedForComposableCoW} from "src/COWShedForComposableCoW.sol";
+import {COWShedWithMerkleSigner} from "src/COWShedWithMerkleSigner.sol";
 import {IComposableCow} from "src/IComposableCow.sol";
 
 bytes32 constant SALT = bytes32(0);
@@ -17,8 +18,10 @@ contract DeployScript is Script {
     struct Deployment {
         COWShed cowShed;
         COWShed cowShedForComposableCoW;
+        COWShed cowShedWithMerkleSigner;
         COWShedFactory factory;
         COWShedFactory factoryForComposableCoW;
+        COWShedFactory factoryWithMerkleSigner;
     }
 
     function run() external virtual {
@@ -37,6 +40,10 @@ contract DeployScript is Script {
         vm.broadcast();
         COWShed cowShedForComposableCoW = new COWShedForComposableCoW{salt: SALT}(composableCoW);
 
+        // Deploy COWShed that validates orders via an owner-signed merkle root
+        vm.broadcast();
+        COWShed cowShedWithMerkleSigner = new COWShedWithMerkleSigner{salt: SALT}();
+
         // Deploy factory
         vm.broadcast();
         COWShedFactory factory = new COWShedFactory{salt: SALT}(address(cowShed));
@@ -45,11 +52,17 @@ contract DeployScript is Script {
         vm.broadcast();
         COWShedFactory factoryForComposableCoW = new COWShedFactory{salt: SALT}(address(cowShedForComposableCoW));
 
+        // Deploy factory
+        vm.broadcast();
+        COWShedFactory factoryWithMerkleSigner = new COWShedFactory{salt: SALT}(address(cowShedWithMerkleSigner));
+
         return Deployment({
             cowShed: cowShed,
             cowShedForComposableCoW: cowShedForComposableCoW,
+            cowShedWithMerkleSigner: cowShedWithMerkleSigner,
             factory: factory,
-            factoryForComposableCoW: factoryForComposableCoW
+            factoryForComposableCoW: factoryForComposableCoW,
+            factoryWithMerkleSigner: factoryWithMerkleSigner
         });
     }
 }

--- a/src/COWShedWithMerkleSigner.sol
+++ b/src/COWShedWithMerkleSigner.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {COWShed} from "./COWShed.sol";
+import {ERC1271MerkleValidator} from "./ERC1271MerkleValidator.sol";
+
+/**
+ * @title COWShed With Merkle Signer
+ * @notice A COWShed implementation that validates CoW Protocol orders via proof of
+ *         inclusion in an owner-signed merkle root, with zero on-chain storage.
+ * @dev Mirrors `COWShedForComposableCoW` (COWShed + ERC1271Forwarder). Here the shed
+ *      is itself the EIP-1271 order owner, and `isValidSignature` is served directly by
+ *      the merkle validator rather than forwarded to ComposableCoW.
+ */
+contract COWShedWithMerkleSigner is COWShed, ERC1271MerkleValidator {
+    /// @dev The proxy owner/admin authorizes roots.
+    function _rootSigner() internal view override returns (address) {
+        return _admin();
+    }
+
+    /// @dev Reuse the shed's EIP-712 domain (chain id + proxy address).
+    function _domainSeparatorV4() internal view override returns (bytes32) {
+        return domainSeparator();
+    }
+}

--- a/src/ERC1271MerkleValidator.sol
+++ b/src/ERC1271MerkleValidator.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {IERC1271} from "./IERC1271.sol";
+import {MerkleProofLib} from "solady/utils/MerkleProofLib.sol";
+import {SignatureCheckerLib} from "solady/utils/SignatureCheckerLib.sol";
+
+/**
+ * @title ERC1271 Merkle Validator
+ * @notice Validates CoW Protocol orders by proving their inclusion in an
+ *         owner-signed merkle root of order digests.
+ * @dev Zero on-chain storage: the root, the owner's signature over the root, and the
+ *      inclusion proof are ALL carried in the ERC-1271 `signature` bytes (supplied by
+ *      the solver in the settlement). The owner signs one root off-chain that commits
+ *      to an arbitrary number of orders; no per-order presign / SSTORE is needed.
+ *
+ *      The settlement computes the GPv2 order digest and passes it as `_hash`, so this
+ *      contract never decodes the order — it only checks that the owner authorized that
+ *      digest. The digest is already bound to the settlement domain + chain, and the
+ *      root signature is bound to this proxy's domain + chain, so neither the leaf nor
+ *      the root can be replayed across chains or across proxies.
+ *
+ *      Revocation is intentionally out of scope for this contract: authorization is
+ *      time-bounded via `validTo`. On-chain (per-root / per-order) revocation is a
+ *      planned follow-up that would layer a storage check on top of this path.
+ */
+abstract contract ERC1271MerkleValidator is IERC1271 {
+    /// @dev EIP-712 typehash for the owner's root commitment.
+    bytes32 internal constant ROOT_TYPE_HASH = keccak256("OrderRoot(bytes32 root,uint256 validTo)");
+
+    /// @dev ERC-1271 magic value returned on successful validation.
+    bytes4 internal constant MAGIC_VALUE = 0x1626ba7e;
+
+    /// @dev The payload the solver carries in the settlement's `signature` field.
+    struct MerkleSignature {
+        bytes32 root; // merkle root of authorized order digests
+        uint256 validTo; // batch-level authorization deadline (unix seconds)
+        bytes rootSignature; // owner signature (EOA or ERC-1271) over OrderRoot(root, validTo)
+        bytes32[] proof; // inclusion proof for this order's digest
+    }
+
+    /// @notice Domain separator binding the root signature to this proxy + chain.
+    function _domainSeparatorV4() internal view virtual returns (bytes32);
+
+    /// @notice The address whose signature authorizes a root (the proxy owner/admin).
+    function _rootSigner() internal view virtual returns (address);
+
+    /**
+     * @param _hash GPv2 order digest, computed and passed by the settlement.
+     * @param signature abi.encoded `MerkleSignature`.
+     * @return `MAGIC_VALUE` if the order is authorized, `bytes4(0)` otherwise (fail closed).
+     */
+    function isValidSignature(bytes32 _hash, bytes memory signature) public view override returns (bytes4) {
+        MerkleSignature memory sig = abi.decode(signature, (MerkleSignature));
+
+        // Ensure the signature hasn't expired
+        if (block.timestamp > sig.validTo) {
+            return bytes4(0);
+        }
+
+        // Verify the owner's signature of the EIP-712 message. The message contains the merkle root and the validTo
+        bytes32 toSign = _rootDigest(sig.root, sig.validTo);
+        if (!SignatureCheckerLib.isValidSignatureNow(_rootSigner(), toSign, sig.rootSignature)) {
+            return bytes4(0);
+        }
+
+        // Verify the order being verified (_hash) is included in the merkle root. Uses the proof and the verified merkle root
+        bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(_hash))));
+        if (!MerkleProofLib.verify(sig.proof, sig.root, leaf)) {
+            return bytes4(0);
+        }
+
+        return MAGIC_VALUE;
+    }
+
+    function _rootDigest(bytes32 root, uint256 validTo) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(ROOT_TYPE_HASH, root, validTo));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparatorV4(), structHash));
+    }
+}

--- a/test/COWShedWithMerkleSigner.t.sol
+++ b/test/COWShedWithMerkleSigner.t.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import {Vm} from "forge-std/Test.sol";
+import {BaseTest} from "test/BaseTest.sol";
+import {COWShedFactory} from "src/COWShedFactory.sol";
+import {COWShedWithMerkleSigner} from "src/COWShedWithMerkleSigner.sol";
+import {ERC1271MerkleValidator} from "src/ERC1271MerkleValidator.sol";
+
+contract COWShedWithMerkleSignerTest is BaseTest {
+    /// @dev ERC-1271 magic value.
+    bytes4 internal constant MAGIC = 0x1626ba7e;
+    /// @dev must match ERC1271MerkleValidator.ROOT_TYPE_HASH.
+    bytes32 internal constant ROOT_TYPE_HASH = keccak256("OrderRoot(bytes32 root,uint256 validTo)");
+
+    COWShedWithMerkleSigner internal merkleImpl;
+    COWShedFactory internal merkleFactory;
+
+    // EOA-owned merkle proxy (owner == user.addr)
+    address internal merkleProxyAddr;
+    COWShedWithMerkleSigner internal merkleProxy;
+
+    // contract-owned merkle proxy (owner == smartWalletAddr, exercises the ERC-1271 owner path)
+    address internal swMerkleProxyAddr;
+    COWShedWithMerkleSigner internal swMerkleProxy;
+
+    // sample order digests committed to the tree; index 0 is the one we prove
+    bytes32[4] internal digests;
+
+    function setUp() public override {
+        super.setUp();
+
+        merkleImpl = new COWShedWithMerkleSigner();
+        merkleFactory = new COWShedFactory(address(merkleImpl));
+
+        merkleProxyAddr = merkleFactory.proxyOf(user.addr);
+        merkleFactory.initializeProxy(user.addr);
+        merkleProxy = COWShedWithMerkleSigner(payable(merkleProxyAddr));
+
+        swMerkleProxyAddr = merkleFactory.proxyOf(smartWalletAddr);
+        merkleFactory.initializeProxy(smartWalletAddr);
+        swMerkleProxy = COWShedWithMerkleSigner(payable(swMerkleProxyAddr));
+
+        digests[0] = keccak256("order-0");
+        digests[1] = keccak256("order-1");
+        digests[2] = keccak256("order-2");
+        digests[3] = keccak256("order-3");
+    }
+
+    function test_isValidSignature_happyPath() public {
+        (bytes32 root, bytes32[] memory proof) = _rootAndProofForFirstDigest();
+        uint256 validTo = block.timestamp + 1 hours;
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, validTo);
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), MAGIC, "authorized order should validate");
+    }
+
+    function test_isValidSignature_expiredBatchFailsClosed() public {
+        // Move time forward so we can set validTo in the past without underflow.
+        vm.warp(1_000_000);
+        (bytes32 root, bytes32[] memory proof) = _rootAndProofForFirstDigest();
+        uint256 validTo = block.timestamp - 1;
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, validTo);
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), bytes4(0), "expired batch must fail closed");
+    }
+
+    function test_isValidSignature_orderNotInTreeFailsClosed() public {
+        (bytes32 root, bytes32[] memory proof) = _rootAndProofForFirstDigest();
+        uint256 validTo = block.timestamp + 1 hours;
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, validTo);
+        // Proof is for digests[0]; ask about an unrelated digest.
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+
+        assertEq(
+            merkleProxy.isValidSignature(keccak256("not-in-tree"), sig), bytes4(0), "non-member must fail closed"
+        );
+    }
+
+    function test_isValidSignature_wrongSignerFailsClosed() public {
+        Vm.Wallet memory attacker = vm.createWallet("attacker");
+        (bytes32 root, bytes32[] memory proof) = _rootAndProofForFirstDigest();
+        uint256 validTo = block.timestamp + 1 hours;
+        // Root signed by someone who is not the proxy owner.
+        bytes memory rootSig = _signRootEOA(attacker, merkleProxyAddr, root, validTo);
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), bytes4(0), "root from non-owner must fail closed");
+    }
+
+    function test_isValidSignature_tamperedValidToFailsClosed() public {
+        (bytes32 root, bytes32[] memory proof) = _rootAndProofForFirstDigest();
+        uint256 signedValidTo = block.timestamp + 1 hours;
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, signedValidTo);
+        // Present a different validTo than the one that was signed.
+        bytes memory sig = _encodeSig(root, signedValidTo + 1, rootSig, proof);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), bytes4(0), "tampered validTo must fail closed");
+    }
+
+    function test_isValidSignature_contractOwnerPath() public {
+        (bytes32 root, bytes32[] memory proof) = _rootAndProofForFirstDigest();
+        uint256 validTo = block.timestamp + 1 hours;
+
+        // The BaseTest SmartWallet validates a signature iff it was pre-stored for the hash.
+        bytes32 rootDigest = _rootDigest(swMerkleProxyAddr, root, validTo);
+        bytes memory rootSig = abi.encode(rootDigest);
+        vm.prank(smartWallet.owner());
+        smartWallet.sign(rootDigest, rootSig);
+
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+        assertEq(swMerkleProxy.isValidSignature(digests[0], sig), MAGIC, "contract owner (ERC-1271) should validate");
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    /// @dev leaf hashing matches @openzeppelin/merkle-tree StandardMerkleTree, leafEncoding ["bytes32"].
+    function _leaf(bytes32 digest) internal pure returns (bytes32) {
+        return keccak256(bytes.concat(keccak256(abi.encode(digest))));
+    }
+
+    /// @dev sorted-pair hashing, matching solady MerkleProofLib / OZ MerkleProof.
+    function _hashPair(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+
+    /// @dev Build a 4-leaf balanced tree and return the root + inclusion proof for digests[0].
+    function _rootAndProofForFirstDigest() internal view returns (bytes32 root, bytes32[] memory proof) {
+        bytes32 l0 = _leaf(digests[0]);
+        bytes32 l1 = _leaf(digests[1]);
+        bytes32 l2 = _leaf(digests[2]);
+        bytes32 l3 = _leaf(digests[3]);
+        bytes32 n01 = _hashPair(l0, l1);
+        bytes32 n23 = _hashPair(l2, l3);
+        root = _hashPair(n01, n23);
+
+        proof = new bytes32[](2);
+        proof[0] = l1;
+        proof[1] = n23;
+    }
+
+    function _rootDigest(address proxy, bytes32 root, uint256 validTo) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(ROOT_TYPE_HASH, root, validTo));
+        return keccak256(
+            abi.encodePacked("\x19\x01", COWShedWithMerkleSigner(payable(proxy)).domainSeparator(), structHash)
+        );
+    }
+
+    function _signRootEOA(Vm.Wallet memory wallet, address proxy, bytes32 root, uint256 validTo)
+        internal
+        view
+        returns (bytes memory)
+    {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(wallet.privateKey, _rootDigest(proxy, root, validTo));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _encodeSig(bytes32 root, uint256 validTo, bytes memory rootSig, bytes32[] memory proof)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(ERC1271MerkleValidator.MerkleSignature(root, validTo, rootSig, proof));
+    }
+}

--- a/test/COWShedWithMerkleSigner.t.sol
+++ b/test/COWShedWithMerkleSigner.t.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.25;
 
 import {Vm} from "forge-std/Test.sol";
-import {BaseTest} from "test/BaseTest.sol";
 import {COWShedFactory} from "src/COWShedFactory.sol";
 import {COWShedWithMerkleSigner} from "src/COWShedWithMerkleSigner.sol";
 import {ERC1271MerkleValidator} from "src/ERC1271MerkleValidator.sol";
+import {BaseTest} from "test/BaseTest.sol";
 
 contract COWShedWithMerkleSignerTest is BaseTest {
     /// @dev ERC-1271 magic value.
@@ -74,9 +74,7 @@ contract COWShedWithMerkleSignerTest is BaseTest {
         // Proof is for digests[0]; ask about an unrelated digest.
         bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
 
-        assertEq(
-            merkleProxy.isValidSignature(keccak256("not-in-tree"), sig), bytes4(0), "non-member must fail closed"
-        );
+        assertEq(merkleProxy.isValidSignature(keccak256("not-in-tree"), sig), bytes4(0), "non-member must fail closed");
     }
 
     function test_isValidSignature_wrongSignerFailsClosed() public {
@@ -143,9 +141,10 @@ contract COWShedWithMerkleSignerTest is BaseTest {
 
     function _rootDigest(address proxy, bytes32 root, uint256 validTo) internal view returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(ROOT_TYPE_HASH, root, validTo));
-        return keccak256(
-            abi.encodePacked("\x19\x01", COWShedWithMerkleSigner(payable(proxy)).domainSeparator(), structHash)
-        );
+        return
+            keccak256(
+                abi.encodePacked("\x19\x01", COWShedWithMerkleSigner(payable(proxy)).domainSeparator(), structHash)
+            );
     }
 
     function _signRootEOA(Vm.Wallet memory wallet, address proxy, bytes32 root, uint256 validTo)


### PR DESCRIPTION
## What

Adds a `COWShed` variant that acts as the EIP-1271 order owner and validates CoW Protocol orders by proving their inclusion in an **owner-signed merkle root of order digests**.

## Motivation
If we wanted to let shed trade we could:
- A) Use https://github.com/cowdao-grants/cow-shed/pull/63 to let the EOA sign an order. This is great for single orders
    -  Problem is that multiple orders needs multiple signatures
- B) Add a hook that presigns one or more order using the Shed
    - Problem 1 is that it needs storage in the settlement contract to approve an order (costs one SSTORE per order)
    - Problem 2 is that, if you create a custom strategy that genertates 1,000 orders that you want to activate/reveal only when the moment is right
            - Then you would need to either pre-approve all of them using presign which is expensive as you need one SSTORE per order. 
            - You would need a custom trusted executor to deal with bundling (pre-approving manu orders at once)

This allows us to generate many orders (the leafs) using our private custom generator, and reveal them when the time is right. We only need to sign once and we don't need to write anything in storage. Then, the user's  private generator could decide when is the moment right to reveal the order and the proof, it will be able to reuse the signature for all 1,000 orders.

## Leaking the signature
The signature will be leaked on the first order, however it should not be a problem, because you also need to present the proof of inclusion, which unless your private generator is deterministic and someone can guess it, its not possible to provide. 

One way to make it non-deterministic, even if you use a open-source public call is by having some randomness added in the appData (i.e. a nonce meta-data). This way, the user controls when to reveal the orders.



## Design decission

### Not using trusted execution
I coukld use #61 to build a new trusted executor for this, but I decided to keep it simple and have a specific shed for this. 

I followed `COWShedForComposableCoW` adding the 1271 into the shed. The merkle validation is stateless and unprivileged (the owner's signed is the only thing we trust)  so routing it through the trustedExecutor role would over-grant arbitrary-call power just to get a pure view function.

I'm not strongly oppinionated on this one, but seems pragmatic to do it as in this PR. Happy to reconsider though.

### Implementation
I consider at first using a trusted executor where we on-chain registration was than in the contract. 

The advantage was that you don't need to sign the order, it works nicely with https://github.com/cowdao-grants/cow-shed/pull/64 to allow us to set the root as part of the shed's creation. The reason I didn't do this is:
- A) It cost storage 
- B) Its not adding something fundmentally new we couldn't do before. Cow-shed has support for composable cow, which allows this already, so I don't think is worth the effort

## Review

Check `src/COWShedWithMerkleSigner.sol` has minimal changes to setup the root signer to the owner of the shed. The meat of the PR is in `ERC1271MerkleValidator` whose comments should explain the 3 steps of the verification.

I used solady for the merkle tree verication, dependency already present in the project. Also for the verification of the signature.

## Test plan
```
forge test --match-path test/COWShedWithMerkleSigner.t.sol -vv  
```

## Out of scope
Even though there's a deadline, would be nice to be able to cancel the whole root. Otherwise, the orders are valid until expiration. 

This will be a follow up PR.
