### PR TITLE
feat: on-chain revocation of merkle-authorized orders

### DIFF
--- a/src/COWShedWithMerkleSigner.sol
+++ b/src/COWShedWithMerkleSigner.sol
@@ -22,4 +22,28 @@ contract COWShedWithMerkleSigner is COWShed, ERC1271MerkleValidator {
     function _domainSeparatorV4() internal view override returns (bytes32) {
         return domainSeparator();
     }
+
+    /// @notice Revoke an entire authorized root (bulk cancel). Only the owner.
+    function revokeRoot(bytes32 root) external onlyAdmin {
+        _revokeRoot(root);
+    }
+
+    /// @notice Revoke several roots in a single call. Only the owner.
+    function revokeRoots(bytes32[] calldata roots) external onlyAdmin {
+        for (uint256 i; i < roots.length; i++) {
+            _revokeRoot(roots[i]);
+        }
+    }
+
+    /// @notice Revoke a single order by its digest, even if its root remains valid. Only the owner.
+    function revokeOrder(bytes32 orderDigest) external onlyAdmin {
+        _revokeOrder(orderDigest);
+    }
+
+    /// @notice Revoke several order digests in a single call. Only the owner.
+    function revokeOrders(bytes32[] calldata orderDigests) external onlyAdmin {
+        for (uint256 i; i < orderDigests.length; i++) {
+            _revokeOrder(orderDigests[i]);
+        }
+    }
 }

--- a/src/ERC1271MerkleValidator.sol
+++ b/src/ERC1271MerkleValidator.sol
@@ -20,9 +20,11 @@ import {SignatureCheckerLib} from "solady/utils/SignatureCheckerLib.sol";
  *      root signature is bound to this proxy's domain + chain, so neither the leaf nor
  *      the root can be replayed across chains or across proxies.
  *
- *      Revocation is intentionally out of scope for this contract: authorization is
- *      time-bounded via `validTo`. On-chain (per-root / per-order) revocation is a
- *      planned follow-up that would layer a storage check on top of this path.
+ *      Authorization is time-bounded via `validTo`, and can additionally be cancelled
+ *      before expiry via on-chain revocation: a whole root (bulk cancel, one SSTORE) or
+ *      a single order digest. Revocations are additive and permanent — to re-enable, the
+ *      owner signs a fresh root. The registry lives at a dedicated, namespaced storage
+ *      slot so it never collides with the shed's own state.
  */
 abstract contract ERC1271MerkleValidator is IERC1271 {
     /// @dev EIP-712 typehash for the owner's root commitment.
@@ -30,6 +32,16 @@ abstract contract ERC1271MerkleValidator is IERC1271 {
 
     /// @dev ERC-1271 magic value returned on successful validation.
     bytes4 internal constant MAGIC_VALUE = 0x1626ba7e;
+
+    /// @dev Namespaced storage slot for the revocation registry. Chosen so it cannot
+    ///      collide with `COWShedStorage.State` (keccak256("COWShed.State")) or the
+    ///      EIP-1967 implementation slot.
+    bytes32 internal constant REVOCATION_STORAGE_SLOT = keccak256("COWShed.MerkleRevocation");
+
+    /// @notice Emitted when an entire root (and therefore every order under it) is revoked.
+    event RootRevoked(bytes32 indexed root);
+    /// @notice Emitted when a single order digest is revoked.
+    event OrderRevoked(bytes32 indexed orderDigest);
 
     /// @dev The payload the solver carries in the settlement's `signature` field.
     struct MerkleSignature {
@@ -45,6 +57,16 @@ abstract contract ERC1271MerkleValidator is IERC1271 {
     /// @notice The address whose signature authorizes a root (the proxy owner/admin).
     function _rootSigner() internal view virtual returns (address);
 
+    /// @notice Whether an entire root has been revoked on-chain.
+    function isRootRevoked(bytes32 root) public view returns (bool) {
+        return _revoked()[_rootKey(root)];
+    }
+
+    /// @notice Whether a single order digest has been revoked on-chain.
+    function isOrderRevoked(bytes32 orderDigest) public view returns (bool) {
+        return _revoked()[_orderKey(orderDigest)];
+    }
+
     /**
      * @param _hash GPv2 order digest, computed and passed by the settlement.
      * @param signature abi.encoded `MerkleSignature`.
@@ -55,6 +77,13 @@ abstract contract ERC1271MerkleValidator is IERC1271 {
 
         // Ensure the signature hasn't expired
         if (block.timestamp > sig.validTo) {
+            return bytes4(0);
+        }
+
+        // Ensure neither the whole batch (root) nor this specific order has been revoked
+        // on-chain. Checked before the expensive signature/proof verification so a revoked
+        // order fails cheaply.
+        if (isRootRevoked(sig.root) || isOrderRevoked(_hash)) {
             return bytes4(0);
         }
 
@@ -76,5 +105,35 @@ abstract contract ERC1271MerkleValidator is IERC1271 {
     function _rootDigest(bytes32 root, uint256 validTo) internal view returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(ROOT_TYPE_HASH, root, validTo));
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparatorV4(), structHash));
+    }
+
+    /// @dev Revoke an entire root; every order proving under it stops validating.
+    function _revokeRoot(bytes32 root) internal {
+        _revoked()[_rootKey(root)] = true;
+        emit RootRevoked(root);
+    }
+
+    /// @dev Revoke a single order digest, even if its root remains otherwise valid.
+    function _revokeOrder(bytes32 orderDigest) internal {
+        _revoked()[_orderKey(orderDigest)] = true;
+        emit OrderRevoked(orderDigest);
+    }
+
+    /// @dev Tags keep root and order keys in disjoint sub-spaces of the shared mapping.
+    function _rootKey(bytes32 root) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked("root", root));
+    }
+
+    function _orderKey(bytes32 orderDigest) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked("order", orderDigest));
+    }
+
+    /// @dev Revocation registry pinned to a dedicated storage slot.
+    function _revoked() private pure returns (mapping(bytes32 => bool) storage revoked) {
+        bytes32 slot = REVOCATION_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            revoked.slot := slot
+        }
     }
 }

--- a/test/COWShedWithMerkleSigner.t.sol
+++ b/test/COWShedWithMerkleSigner.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import {Vm} from "forge-std/Test.sol";
+import {COWShed} from "src/COWShed.sol";
 import {COWShedFactory} from "src/COWShedFactory.sol";
 import {COWShedWithMerkleSigner} from "src/COWShedWithMerkleSigner.sol";
 import {ERC1271MerkleValidator} from "src/ERC1271MerkleValidator.sol";
@@ -112,6 +113,66 @@ contract COWShedWithMerkleSignerTest is BaseTest {
         assertEq(swMerkleProxy.isValidSignature(digests[0], sig), MAGIC, "contract owner (ERC-1271) should validate");
     }
 
+    function test_revokeRoot_invalidatesEntireBatch() public {
+        (bytes32 root, bytes32[] memory proof) = _rootAndProof(0);
+        uint256 validTo = block.timestamp + 1 hours;
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, validTo);
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), MAGIC, "valid before revocation");
+
+        vm.prank(user.addr);
+        merkleProxy.revokeRoot(root);
+
+        assertTrue(merkleProxy.isRootRevoked(root), "root should be marked revoked");
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), bytes4(0), "revoked root must fail closed");
+    }
+
+    function test_revokeOrder_invalidatesOnlyThatOrder() public {
+        uint256 validTo = block.timestamp + 1 hours;
+        (bytes32 root, bytes32[] memory proof0) = _rootAndProof(0);
+        (, bytes32[] memory proof2) = _rootAndProof(2);
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, validTo);
+
+        vm.prank(user.addr);
+        merkleProxy.revokeOrder(digests[0]);
+
+        bytes memory sig0 = _encodeSig(root, validTo, rootSig, proof0);
+        bytes memory sig2 = _encodeSig(root, validTo, rootSig, proof2);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig0), bytes4(0), "revoked order must fail closed");
+        assertEq(merkleProxy.isValidSignature(digests[2], sig2), MAGIC, "sibling order under same root still valid");
+    }
+
+    function test_revokeRoots_batch() public {
+        (bytes32 root, bytes32[] memory proof) = _rootAndProof(0);
+        uint256 validTo = block.timestamp + 1 hours;
+        bytes memory rootSig = _signRootEOA(user, merkleProxyAddr, root, validTo);
+        bytes memory sig = _encodeSig(root, validTo, rootSig, proof);
+
+        bytes32[] memory roots = new bytes32[](2);
+        roots[0] = keccak256("some-other-root");
+        roots[1] = root;
+
+        vm.prank(user.addr);
+        merkleProxy.revokeRoots(roots);
+
+        assertEq(merkleProxy.isValidSignature(digests[0], sig), bytes4(0), "batch-revoked root must fail closed");
+    }
+
+    function test_revoke_onlyOwner() public {
+        (bytes32 root,) = _rootAndProof(0);
+        address attacker = makeAddr("attacker");
+
+        vm.prank(attacker);
+        vm.expectRevert(COWShed.OnlyAdmin.selector);
+        merkleProxy.revokeRoot(root);
+
+        vm.prank(attacker);
+        vm.expectRevert(COWShed.OnlyAdmin.selector);
+        merkleProxy.revokeOrder(digests[0]);
+    }
+
     // --- helpers ---------------------------------------------------------
 
     /// @dev leaf hashing matches @openzeppelin/merkle-tree StandardMerkleTree, leafEncoding ["bytes32"].
@@ -126,6 +187,11 @@ contract COWShedWithMerkleSignerTest is BaseTest {
 
     /// @dev Build a 4-leaf balanced tree and return the root + inclusion proof for digests[0].
     function _rootAndProofForFirstDigest() internal view returns (bytes32 root, bytes32[] memory proof) {
+        return _rootAndProof(0);
+    }
+
+    /// @dev Build a 4-leaf balanced tree and return the root + inclusion proof for digests[index].
+    function _rootAndProof(uint256 index) internal view returns (bytes32 root, bytes32[] memory proof) {
         bytes32 l0 = _leaf(digests[0]);
         bytes32 l1 = _leaf(digests[1]);
         bytes32 l2 = _leaf(digests[2]);
@@ -135,8 +201,19 @@ contract COWShedWithMerkleSignerTest is BaseTest {
         root = _hashPair(n01, n23);
 
         proof = new bytes32[](2);
-        proof[0] = l1;
-        proof[1] = n23;
+        if (index == 0) {
+            proof[0] = l1;
+            proof[1] = n23;
+        } else if (index == 1) {
+            proof[0] = l0;
+            proof[1] = n23;
+        } else if (index == 2) {
+            proof[0] = l3;
+            proof[1] = n01;
+        } else {
+            proof[0] = l2;
+            proof[1] = n01;
+        }
     }
 
     function _rootDigest(address proxy, bytes32 root, uint256 validTo) internal view returns (bytes32) {


### PR DESCRIPTION
> Follow up on #65 

## What

Adds owner-only **on-chain cancellation** on top of the signed-root validator. Let you invalidate

- Merkle roots: `revokeRoot(bytes32)` / `revokeRoots(bytes32[])`
- Orders: `revokeOrder(bytes32)` / `revokeOrders(bytes32[])`

`isValidSignature` checks the revocation registry, and act acordinly.

## Why

The base validator is stateless and time-bounded via `validTo`. That covers auto-expiry but not *immediate* cancellation before expiry. On-chain revocation fills that gap:

Bulk cancel costs one SSTORE regardless of how many orders the root commits to.

Single order cancelations come handy if you only want to cherry-pick some orders in the merkle tree that needs cancelation.


## Test plan

```
forge test --match-path test/COWShedWithMerkleSigner.t.sol -vv 
```